### PR TITLE
Reconcile deleted items

### DIFF
--- a/internal/executor/cmd.go
+++ b/internal/executor/cmd.go
@@ -82,7 +82,7 @@ func (c *command) RunCaptureCombined() ([]byte, error) {
 	var out bytes.Buffer
 	err := c.WithCombinedOutput(&out).RunSingle()
 	if err != nil {
-		return nil, fmt.Errorf("error running '%s': %v, %v", strings.Join(c.cmd.Args, " "), err, out.String())
+		return out.Bytes(), fmt.Errorf("error running '%s': %v, %v", strings.Join(c.cmd.Args, " "), err, out.String())
 	}
 
 	return out.Bytes(), nil

--- a/internal/provider/object.go
+++ b/internal/provider/object.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"context"
+	"errors"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -29,6 +30,10 @@ func objectDelete(ctx context.Context, d *schema.ResourceData, meta interface{})
 func objectOperation(ctx context.Context, d *schema.ResourceData, operation func(secret bitwarden.Object) (*bitwarden.Object, error)) diag.Diagnostics {
 	obj, err := operation(objectStructFromData(d))
 	if err != nil {
+		if errors.Is(err, bitwarden.ErrNotFound) {
+			d.SetId("")
+			return diag.Diagnostics{}
+		}
 		return diag.FromErr(err)
 	}
 


### PR DESCRIPTION
Correctly identify situations when an item that is present in the state has been removed from the Vault, enabling Terraform to recreate it.