### PR TITLE
updated documentation to version bump the the provider version

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ terraform {
   required_providers {
     bitwarden = {
       source  = "maxlaverse/bitwarden"
-      version = "0.0.1"
+      version = "0.1.0"
     }
   }
   required_version = ">= 1.0.2"

--- a/docs/index.md
+++ b/docs/index.md
@@ -54,7 +54,7 @@ terraform {
   required_providers {
     bitwarden = {
       source  = "maxlaverse/bitwarden"
-      version = "0.0.1"
+      version = "0.1.0"
     }
   }
   required_version = ">= 1.0.2"

--- a/examples/quick/provider.tf
+++ b/examples/quick/provider.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     bitwarden = {
       source  = "maxlaverse/bitwarden"
-      version = "0.0.1"
+      version = "0.1.0"
     }
   }
   required_version = ">= 1.0.2"


### PR DESCRIPTION
The version of the plugin was not updated to `0.1.0` in the last version bump