### PR TITLE
set I_REALLY_WANT_VOLATILE_STORAGE on Vaultwarden during tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,6 +25,7 @@ jobs:
         image: vaultwarden/server:latest
         env:
           ADMIN_TOKEN: test1234
+          I_REALLY_WANT_VOLATILE_STORAGE: "true"
         ports:
           - 8080:80
         options: >-


### PR DESCRIPTION
The latest version of Vaultwarden requires the `I_REALLY_WANT_VOLATILE_STORAGE` to be set when no volume is configured, in order for the server to start.