### PR TITLE
fix using session key with official servers

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -75,12 +75,12 @@ provider "bitwarden" {
 ### Required
 
 - `email` (String) Login Email of the Vault.
-- `master_password` (String) Master password of the Vault. Do not commit this information in Git unless you know what you're doing. Prefer using a Terraform `variable {}` in order to inject this value from the environment.
 
 ### Optional
 
 - `client_id` (String) Client ID.
 - `client_secret` (String) Client Secret. Do not commit this information in Git unless you know what you're doing. Prefer using a Terraform `variable {}` in order to inject this value from the environment.
+- `master_password` (String) Master password of the Vault. Do not commit this information in Git unless you know what you're doing. Prefer using a Terraform `variable {}` in order to inject this value from the environment.
 - `server` (String) Bitwarden Server URL (default: https://vault.bitwarden.com).
 - `session_key` (String) (EXPERIMENTAL) A Bitwarden Session Key.
 - `vault_path` (String) Alternative directory for storing the Vault locally.

--- a/internal/bitwarden/bw/models.go
+++ b/internal/bitwarden/bw/models.go
@@ -1,12 +1,19 @@
 package bw
 
-import "time"
+import (
+	"strings"
+	"time"
+)
 
 type ItemType int
 
 const (
 	ItemTypeLogin      ItemType = 1
 	ItemTypeSecureNote ItemType = 2
+)
+
+const (
+	DefaultBitwardenServerURL = "https://vault.bitwarden.com"
 )
 
 type FieldType int
@@ -41,12 +48,22 @@ type Status struct {
 	Status    VaultStatus `json:"status,omitempty"`
 }
 
-func (s *Status) VaultOf(email, serverUrl string) bool {
-	return s.ServerURL == serverUrl && s.UserEmail == email
+func (s *Status) VaultFromServer(serverUrl string) bool {
+	providerServerUrl := trimSlashSuffix(serverUrl)
+	vaultServerUrl := trimSlashSuffix(s.ServerURL)
+	return vaultServerUrl == providerServerUrl || len(vaultServerUrl) == 0 && providerServerUrl == DefaultBitwardenServerURL
+}
+
+func (s *Status) VaultOfUser(email string) bool {
+	return s.UserEmail == email
 }
 
 func (s *Status) FreshDataFile() bool {
 	return len(s.UserEmail) == 0 && len(s.ServerURL) == 0 && s.Status == StatusUnauthenticated
+}
+
+func trimSlashSuffix(serverUrl string) string {
+	return strings.TrimSuffix(serverUrl, "/")
 }
 
 type Login struct {

--- a/internal/bitwarden/bw/models.go
+++ b/internal/bitwarden/bw/models.go
@@ -58,10 +58,6 @@ func (s *Status) VaultOfUser(email string) bool {
 	return s.UserEmail == email
 }
 
-func (s *Status) FreshDataFile() bool {
-	return len(s.UserEmail) == 0 && len(s.ServerURL) == 0 && s.Status == StatusUnauthenticated
-}
-
 func trimSlashSuffix(serverUrl string) string {
 	return strings.TrimSuffix(serverUrl, "/")
 }

--- a/internal/bitwarden/bw/models_test.go
+++ b/internal/bitwarden/bw/models_test.go
@@ -1,0 +1,63 @@
+package bw
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestVaultFromServer(t *testing.T) {
+	testCases := []struct {
+		vaultUrl       string
+		providerUrl    string
+		expectedResult bool
+	}{
+		{
+			vaultUrl:       "http://127.0.0.1",
+			providerUrl:    "http://127.0.0.1",
+			expectedResult: true,
+		},
+		{
+			vaultUrl:       "http://127.0.0.1/",
+			providerUrl:    "http://127.0.0.1",
+			expectedResult: true,
+		},
+		{
+			vaultUrl:       "http://127.0.0.1",
+			providerUrl:    "http://127.0.0.1/",
+			expectedResult: true,
+		},
+		{
+			vaultUrl:       "",
+			providerUrl:    "https://vault.bitwarden.com",
+			expectedResult: true,
+		},
+		{
+			vaultUrl:       "https://vault.bitwarden.com/",
+			providerUrl:    "https://vault.bitwarden.com",
+			expectedResult: true,
+		},
+		{
+			vaultUrl:       "http://127.0.0.1",
+			providerUrl:    "http://127.0.0.1/s",
+			expectedResult: false,
+		},
+		{
+			vaultUrl:       "http://127.0.0.2",
+			providerUrl:    "http://127.0.0.1",
+			expectedResult: false,
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run("", func(t *testing.T) {
+			status := &Status{
+				ServerURL: test.vaultUrl,
+			}
+			match := status.VaultFromServer(test.providerUrl)
+
+			assert.Equal(t, test.expectedResult, match)
+		})
+	}
+
+}

--- a/internal/bitwarden/bw/models_test.go
+++ b/internal/bitwarden/bw/models_test.go
@@ -61,3 +61,34 @@ func TestVaultFromServer(t *testing.T) {
 	}
 
 }
+
+func TestVaultOfUser(t *testing.T) {
+	testCases := []struct {
+		vaultEmail     string
+		providerEmail  string
+		expectedResult bool
+	}{
+		{
+			vaultEmail:     "test@laverse.net",
+			providerEmail:  "test@laverse.net",
+			expectedResult: true,
+		},
+		{
+			vaultEmail:     "test@laverse.net",
+			providerEmail:  "unknown@laverse.net",
+			expectedResult: false,
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run("", func(t *testing.T) {
+			status := &Status{
+				UserEmail: test.vaultEmail,
+			}
+			match := status.VaultOfUser(test.providerEmail)
+
+			assert.Equal(t, test.expectedResult, match)
+		})
+	}
+
+}

--- a/internal/provider/provider_auth_test.go
+++ b/internal/provider/provider_auth_test.go
@@ -1,0 +1,100 @@
+package provider
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+const (
+	testResource = `
+	resource "bitwarden_item_login" "foo" {
+		provider = bitwarden
+		name     = "test"
+	}
+	`
+)
+
+func TestAccProviderAuthUsernamePassword(t *testing.T) {
+	ensureVaultwardenHasUser(t)
+	validProvider := usernamePasswordTestProvider(testEmail, testPassword)
+	invalidPassword := usernamePasswordTestProvider(testEmail, "incorrect-password")
+	invalidAccount := usernamePasswordTestProvider("unknown-account@laverse.net", testPassword)
+
+	resource.UnitTest(t, resource.TestCase{
+		ProviderFactories: providerFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      invalidAccount + testResource,
+				ExpectError: regexp.MustCompile("Username or password is incorrect"),
+			}, {
+				// We need to login with a valid account if we want to be able to
+				// test an invalid master password, as we do bellow.
+				Config: validProvider + testResource,
+				Check:  checkResourceId(),
+			}, {
+				Config:      invalidPassword + testResource,
+				ExpectError: regexp.MustCompile("Invalid master password"),
+			}, {
+				// We need to finish with a valid example if we don't want the TestStep to
+				// fail on post-destroy.
+				Config: validProvider + testResource,
+				Check:  checkResourceId(),
+			},
+		},
+	})
+}
+
+func TestAccProviderAuthSessionKey(t *testing.T) {
+	ensureVaultwardenHasUser(t)
+	sessionKey, vaultPath := getTestSessionKey(t)
+	validProvider := sessionKeyTestProvider(testEmail, vaultPath, sessionKey)
+	invalidSessionKey := sessionKeyTestProvider(testEmail, vaultPath, "invalid-session-key")
+
+	resource.UnitTest(t, resource.TestCase{
+		ProviderFactories: providerFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      invalidSessionKey + testResource,
+				ExpectError: regexp.MustCompile("unable to unlock Vault with provided session key"),
+			},
+			{
+				// We need to finish with a valid example if we don't want the TestStep to
+				// fail on post-destroy.
+				Config: validProvider + testResource,
+				Check:  checkResourceId(),
+			},
+		},
+	})
+}
+
+func sessionKeyTestProvider(email, vaultPath, sessionKey string) string {
+	return fmt.Sprintf(`
+	provider "bitwarden" {
+		server          = "%s"
+		email           = "%s"
+		vault_path = "%s"
+		session_key = "%s"
+	}
+`, testServerURL, email, vaultPath, sessionKey)
+}
+
+func usernamePasswordTestProvider(email, password string) string {
+	return fmt.Sprintf(`
+	provider "bitwarden" {
+		master_password = "%s"
+		server          = "%s"
+		email           = "%s"
+	}
+`, password, testServerURL, email)
+}
+
+func checkResourceId() resource.TestCheckFunc {
+	return resource.ComposeTestCheckFunc(
+		resource.TestMatchResourceAttr(
+			"bitwarden_item_login.foo", attributeID, regexp.MustCompile("^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-4[a-fA-F0-9]{3}-[8|9|aA|bB][a-fA-F0-9]{3}-[a-fA-F0-9]{12}$"),
+		),
+	)
+}

--- a/internal/provider/provider_bitwarden_client_test.go
+++ b/internal/provider/provider_bitwarden_client_test.go
@@ -25,7 +25,7 @@ func TestProviderReauthenticateWithPasswordIfAuthenticatedOnDifferentServer(t *t
 		"master_password": "master-password-9",
 	}
 
-	diag := New("dev")().Configure(context.Background(), terraform.NewResourceConfigRaw(providerConfiguration))
+	diag := New(versionDev)().Configure(context.Background(), terraform.NewResourceConfigRaw(providerConfiguration))
 
 	if !assert.False(t, diag.HasError()) {
 		t.Fatalf("unexpected error: %v", diag[0])
@@ -53,7 +53,7 @@ func TestProviderReauthenticateWithPasswordIfAuthenticatedWithDifferentUser(t *t
 		"master_password": "master-password-9",
 	}
 
-	diag := New("dev")().Configure(context.Background(), terraform.NewResourceConfigRaw(providerConfiguration))
+	diag := New(versionDev)().Configure(context.Background(), terraform.NewResourceConfigRaw(providerConfiguration))
 
 	if !assert.False(t, diag.HasError()) {
 		t.Fatalf("unexpected error: %v", diag[0])
@@ -79,7 +79,7 @@ func TestProviderDoesntLogoutFirstIfUnauthenticated(t *testing.T) {
 		"master_password": "master-password-9",
 	}
 
-	diag := New("dev")().Configure(context.Background(), terraform.NewResourceConfigRaw(providerConfiguration))
+	diag := New(versionDev)().Configure(context.Background(), terraform.NewResourceConfigRaw(providerConfiguration))
 
 	if !assert.False(t, diag.HasError()) {
 		t.Fatalf("unexpected error: %v", diag[0])
@@ -109,7 +109,7 @@ func TestProviderReauthenticateWithAPIIfAuthenticatedWithDifferentUser(t *testin
 		"master_password": "master-password-9",
 	}
 
-	diag := New("dev")().Configure(context.Background(), terraform.NewResourceConfigRaw(providerConfiguration))
+	diag := New(versionDev)().Configure(context.Background(), terraform.NewResourceConfigRaw(providerConfiguration))
 
 	if !assert.False(t, diag.HasError()) {
 		t.Fatalf("unexpected error: %v", diag[0])
@@ -136,40 +136,15 @@ func TestProviderWithSessionKeySync(t *testing.T) {
 		"session_key": "abcd1234",
 	}
 
-	diag := New("dev")().Configure(context.Background(), terraform.NewResourceConfigRaw(raw))
+	// We specifically set the provider's version to something else than 'versionDev'
+	// in order to capture 'sync' calls.
+	diag := New("not-dev")().Configure(context.Background(), terraform.NewResourceConfigRaw(raw))
 	if !assert.False(t, diag.HasError()) {
 		t.Fatal(diag[0])
 	}
 
 	assert.Equal(t, []string{
 		"status",
-		"sync",
-	}, commandsExecuted())
-}
-
-func TestProviderWithSessionKeyAndMasterPasswordCanUnlock(t *testing.T) {
-	restoreDefaultExecutor := useFakeExecutor(t, map[string]string{
-		"status":                                 `{"serverURL": "http://127.0.0.1/", "userEmail": "test@laverse.net", "status": "locked"}`,
-		"sync":                                   ``,
-		"unlock --raw --passwordenv BW_PASSWORD": `session-key1234`,
-	})
-	defer restoreDefaultExecutor(t)
-
-	raw := map[string]interface{}{
-		"server":          "http://127.0.0.1/",
-		"email":           "test@laverse.net",
-		"session_key":     "abcd1234",
-		"master_password": "master-password-9",
-	}
-
-	diag := New("dev")().Configure(context.Background(), terraform.NewResourceConfigRaw(raw))
-	if !assert.False(t, diag.HasError()) {
-		t.Fatal(diag[0])
-	}
-
-	assert.Equal(t, []string{
-		"status",
-		"unlock --raw --passwordenv BW_PASSWORD",
 		"sync",
 	}, commandsExecuted())
 }

--- a/internal/provider/provider_validation_test.go
+++ b/internal/provider/provider_validation_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestProviderSchemaValidity(t *testing.T) {
-	if err := New("dev")().InternalValidate(); err != nil {
+	if err := New(versionDev)().InternalValidate(); err != nil {
 		t.Fatalf("err: %s", err)
 	}
 }
@@ -23,7 +23,7 @@ func TestProviderAuthAPIMethodValid(t *testing.T) {
 		"master_password": "master-password-9",
 	}
 
-	diag := New("dev")().Validate(terraform.NewResourceConfigRaw(raw))
+	diag := New(versionDev)().Validate(terraform.NewResourceConfigRaw(raw))
 
 	assert.False(t, diag.HasError())
 }
@@ -36,7 +36,7 @@ func TestProviderAuthAPIMethodMissingClientIDThrowsError(t *testing.T) {
 		"master_password": "master-password-9",
 	}
 
-	diag := New("dev")().Validate(terraform.NewResourceConfigRaw(raw))
+	diag := New(versionDev)().Validate(terraform.NewResourceConfigRaw(raw))
 
 	if assert.True(t, diag.HasError()) {
 		assert.Equal(t, "Missing required argument", diag[0].Summary)
@@ -52,7 +52,7 @@ func TestProviderAuthAPIMethodMissingClientSecretThrowsError(t *testing.T) {
 		"master_password": "master-password-9",
 	}
 
-	diag := New("dev")().Validate(terraform.NewResourceConfigRaw(raw))
+	diag := New(versionDev)().Validate(terraform.NewResourceConfigRaw(raw))
 
 	if assert.True(t, diag.HasError()) {
 		assert.Equal(t, "Missing required argument", diag[0].Summary)
@@ -68,7 +68,7 @@ func TestProviderAuthAPIMethodMissingMasterPasswordThrowsError(t *testing.T) {
 		"client_secret": "client-secret-5678",
 	}
 
-	diag := New("dev")().Validate(terraform.NewResourceConfigRaw(raw))
+	diag := New(versionDev)().Validate(terraform.NewResourceConfigRaw(raw))
 
 	if assert.True(t, diag.HasError()) {
 		assert.Equal(t, "Missing required argument", diag[0].Summary)
@@ -82,7 +82,7 @@ func TestProviderAuthPasswordMethodMissingMasterPasswordThrowsError(t *testing.T
 		"email":  "test@laverse.net",
 	}
 
-	diag := New("dev")().Validate(terraform.NewResourceConfigRaw(raw))
+	diag := New(versionDev)().Validate(terraform.NewResourceConfigRaw(raw))
 
 	if assert.True(t, diag.HasError()) {
 		assert.Equal(t, "Missing required argument", diag[0].Summary)
@@ -92,13 +92,12 @@ func TestProviderAuthPasswordMethodMissingMasterPasswordThrowsError(t *testing.T
 
 func TestProviderAuthSessionMethodValid(t *testing.T) {
 	raw := map[string]interface{}{
-		"server":          "http://127.0.0.1/",
-		"email":           "test@laverse.net",
-		"session_key":     "1234",
-		"master_password": "master-password-9",
+		"server":      "http://127.0.0.1/",
+		"email":       "test@laverse.net",
+		"session_key": "1234",
 	}
 
-	diag := New("dev")().Validate(terraform.NewResourceConfigRaw(raw))
+	diag := New(versionDev)().Validate(terraform.NewResourceConfigRaw(raw))
 
 	assert.False(t, diag.HasError())
 }
@@ -109,7 +108,7 @@ func TestProviderAuthAllMethodsMissingEmailThrowsError(t *testing.T) {
 		"master_password": "master-password-9",
 	}
 
-	diag := New("dev")().Validate(terraform.NewResourceConfigRaw(raw))
+	diag := New(versionDev)().Validate(terraform.NewResourceConfigRaw(raw))
 
 	if assert.True(t, diag.HasError()) {
 		assert.Equal(t, "Missing required argument", diag[0].Summary)
@@ -123,7 +122,7 @@ func TestProviderAuthAllMethodsMissingServerNoError(t *testing.T) {
 		"master_password": "master-password-9",
 	}
 
-	diag := New("dev")().Validate(terraform.NewResourceConfigRaw(raw))
+	diag := New(versionDev)().Validate(terraform.NewResourceConfigRaw(raw))
 
 	assert.False(t, diag.HasError())
 }


### PR DESCRIPTION
Fixes https://github.com/maxlaverse/terraform-provider-bitwarden/issues/42#issuecomment-1308492506

Changes:
* fixed comparison of local Vault and Provider's server URLs that would fail if one is suffixed with `/`
* fixed comparison of local Vault and Provider's server URLs when using official Bitwarden servers
* prevented using session key together with `master_password` anymore. The session key support only exists because users don't want to provided the master password.
* improved error message when session key is invalid
* added tests for logging in user session key
* disabled Vault sync on all tests