### PR TITLE
remove WithOutput()

### DIFF
--- a/internal/command/cmd_retryable.go
+++ b/internal/command/cmd_retryable.go
@@ -1,7 +1,6 @@
 package command
 
 import (
-	"io"
 	"log"
 	"time"
 )
@@ -31,11 +30,6 @@ func (c *retryableCommand) AppendEnv(envs []string) Command {
 }
 func (c *retryableCommand) WithStdin(dir string) Command {
 	c.cmd.WithStdin(dir)
-	return c
-}
-
-func (c *retryableCommand) WithOutput(out io.Writer) Command {
-	c.cmd.WithOutput(out)
 	return c
 }
 

--- a/internal/command/test/cmd.go
+++ b/internal/command/test/cmd.go
@@ -2,7 +2,6 @@ package test
 
 import (
 	"fmt"
-	"io"
 	"strings"
 
 	"github.com/maxlaverse/terraform-provider-bitwarden/internal/command"
@@ -31,10 +30,6 @@ func (c *testCommand) AppendEnv(envs []string) command.Command {
 }
 
 func (c *testCommand) WithStdin(dir string) command.Command {
-	return c
-}
-
-func (c *testCommand) WithOutput(out io.Writer) command.Command {
 	return c
 }
 

--- a/internal/provider/provider_utils_test.go
+++ b/internal/provider/provider_utils_test.go
@@ -1,7 +1,6 @@
 package provider
 
 import (
-	"bytes"
 	"fmt"
 	"os"
 	"os/exec"
@@ -92,25 +91,24 @@ func getTestSessionKey(t *testing.T) (string, string) {
 		fmt.Sprintf("BW_PASSWORD=%s", testPassword),
 	}
 
-	var out bytes.Buffer
-
-	_, err = command.New(bwExecutable, "login", testEmail, "--raw", "--passwordenv", "BW_PASSWORD").WithOutput(&out).AppendEnv(env).Run()
+	_, err = command.New(bwExecutable, "login", testEmail, "--raw", "--passwordenv", "BW_PASSWORD").AppendEnv(env).Run()
 	if err != nil && !strings.Contains(err.Error(), "You are already logged in as test@laverse.net") {
 		t.Fatal(err)
 	}
-	_, err = command.New(bwExecutable, "unlock", "--raw", "--passwordenv", "BW_PASSWORD").WithOutput(&out).AppendEnv(env).Run()
+
+	out, err := command.New(bwExecutable, "unlock", "--raw", "--passwordenv", "BW_PASSWORD").AppendEnv(env).Run()
 	if err != nil {
 		t.Fatal(err)
 	}
-	sessionKey := out.String()
+	sessionKey := string(out)
 
-	_, err = command.New(bwExecutable, "status", "--session", sessionKey).WithOutput(&out).AppendEnv(env).Run()
+	out, err = command.New(bwExecutable, "status", "--session", sessionKey).AppendEnv(env).Run()
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	if !strings.Contains(out.String(), `"status":"unlocked"`) {
-		t.Fatal(out.String())
+	if !strings.Contains(string(out), `"status":"unlocked"`) {
+		t.Fatal(string(out))
 	}
 	return sessionKey, abs
 }


### PR DESCRIPTION
Simplifies the `Command` interface and implementation by removing `WithOutput()` which was only used in tests.