### PR TITLE
base64 encode ourselves

### DIFF
--- a/internal/bitwarden/bw/client.go
+++ b/internal/bitwarden/bw/client.go
@@ -2,6 +2,7 @@ package bw
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -81,7 +82,7 @@ func DisableRetryBackoff() Options {
 }
 
 func (c *client) CreateObject(ctx context.Context, obj Object) (*Object, error) {
-	objEncoded, err := c.encode(ctx, obj)
+	objEncoded, err := c.encode(obj)
 	if err != nil {
 		return nil, err
 	}
@@ -128,7 +129,7 @@ func (c *client) CreateAttachment(ctx context.Context, itemId string, filePath s
 }
 
 func (c *client) EditObject(ctx context.Context, obj Object) (*Object, error) {
-	objEncoded, err := c.encode(ctx, obj)
+	objEncoded, err := c.encode(obj)
 	if err != nil {
 		return nil, err
 	}
@@ -323,15 +324,10 @@ func (c *client) env() []string {
 	return defaultEnv
 }
 
-func (c *client) encode(ctx context.Context, item Object) (string, error) {
+func (c *client) encode(item Object) (string, error) {
 	newOut, err := json.Marshal(item)
 	if err != nil {
 		return "", fmt.Errorf("marshalling error: %v, %v", err, string(newOut))
 	}
-
-	out, err := c.cmd("encode").WithStdin(string(newOut)).Run(ctx)
-	if err != nil {
-		return "", fmt.Errorf("encoding error: %v, %v", err, string(newOut))
-	}
-	return string(out), err
+	return base64.RawStdEncoding.EncodeToString(newOut), nil
 }

--- a/internal/bitwarden/bw/client_test.go
+++ b/internal/bitwarden/bw/client_test.go
@@ -10,14 +10,14 @@ import (
 
 func TestCreateObjectEncoding(t *testing.T) {
 	removeMocks, commandsExecuted := test_command.MockCommands(t, map[string]string{
-		"encode":       `e30K`,
-		"create  e30K": `{}`,
+		"create item eyJncm91cHMiOm51bGwsImxvZ2luIjp7fSwib2JqZWN0IjoiaXRlbSIsInNlY3VyZU5vdGUiOnt9LCJ0eXBlIjoxLCJmaWVsZHMiOlt7Im5hbWUiOiJ0ZXN0IiwidmFsdWUiOiJwYXNzZWQiLCJ0eXBlIjowLCJsaW5rZWRJZCI6bnVsbH1dfQ": `{}`,
 	})
 	defer removeMocks(t)
 
 	b := NewClient("dummy")
 	_, err := b.CreateObject(context.Background(), Object{
-		Type: ItemTypeLogin,
+		Type:   ItemTypeLogin,
+		Object: ObjectTypeItem,
 		Fields: []Field{
 			{
 				Name:  "test",
@@ -28,9 +28,8 @@ func TestCreateObjectEncoding(t *testing.T) {
 	})
 
 	assert.NoError(t, err)
-	if assert.Len(t, commandsExecuted(), 2) {
-		assert.Equal(t, "{\"groups\":null,\"login\":{},\"secureNote\":{},\"type\":1,\"fields\":[{\"name\":\"test\",\"value\":\"passed\",\"type\":0,\"linkedId\":null}]}:/:encode", commandsExecuted()[0])
-		assert.Equal(t, "create  e30K", commandsExecuted()[1])
+	if assert.Len(t, commandsExecuted(), 1) {
+		assert.Equal(t, "create item eyJncm91cHMiOm51bGwsImxvZ2luIjp7fSwib2JqZWN0IjoiaXRlbSIsInNlY3VyZU5vdGUiOnt9LCJ0eXBlIjoxLCJmaWVsZHMiOlt7Im5hbWUiOiJ0ZXN0IiwidmFsdWUiOiJwYXNzZWQiLCJ0eXBlIjowLCJsaW5rZWRJZCI6bnVsbH1dfQ", commandsExecuted()[0])
 	}
 }
 


### PR DESCRIPTION
Spawning a `bw` command is slow, and the `encode` code is and has always been base64 encoding stdin. Let's try switching to our own implementation.