### PR TITLE
use less folders in test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,4 @@ terraform-lock
 
 # Code coverage artifact
 profile.cov
+internal/provider/.bitwarden/

--- a/internal/provider/data_source_folder_test.go
+++ b/internal/provider/data_source_folder_test.go
@@ -9,8 +9,6 @@ import (
 func TestAccDataSourceFolderAttributes(t *testing.T) {
 	ensureVaultwardenConfigured(t)
 
-	resourceName := "bitwarden_folder.foo"
-
 	resource.UnitTest(t, resource.TestCase{
 		ProviderFactories: providerFactories,
 		Steps: []resource.TestStep{
@@ -19,7 +17,7 @@ func TestAccDataSourceFolderAttributes(t *testing.T) {
 			},
 			{
 				Config: tfConfigProvider() + tfConfigResourceFolder() + tfConfigDataFolder(),
-				Check:  checkObject(resourceName),
+				Check:  checkObject("data.bitwarden_folder.foo_data"),
 			},
 		},
 	})

--- a/internal/provider/data_source_item_login_test.go
+++ b/internal/provider/data_source_item_login_test.go
@@ -15,10 +15,10 @@ func TestAccDataSourceItemLoginAttributes(t *testing.T) {
 		ProviderFactories: providerFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: tfConfigProvider() + tfConfigResourceFolder() + tfConfigResourceItemLogin(),
+				Config: tfConfigProvider() + tfConfigResourceItemLogin(),
 			},
 			{
-				Config: tfConfigProvider() + tfConfigResourceFolder() + tfConfigResourceItemLogin() + tfConfigDataItemLogin(),
+				Config: tfConfigProvider() + tfConfigResourceItemLogin() + tfConfigDataItemLogin(),
 				Check:  checkItemLogin("data.bitwarden_item_login.foo_data"),
 			},
 		},
@@ -46,10 +46,10 @@ func TestAccDataSourceItemLoginFailsOnWrongResourceType(t *testing.T) {
 		ProviderFactories: providerFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: tfConfigProvider() + tfConfigResourceFolder() + tfConfigResourceItemSecureNote(),
+				Config: tfConfigProvider() + tfConfigResourceItemSecureNote(),
 			},
 			{
-				Config:      tfConfigProvider() + tfConfigResourceFolder() + tfConfigResourceItemSecureNote() + tfConfigDataItemLoginCrossReference(),
+				Config:      tfConfigProvider() + tfConfigResourceItemSecureNote() + tfConfigDataItemLoginCrossReference(),
 				ExpectError: regexp.MustCompile("Error: returned object type does not match requested object type"),
 			},
 		},
@@ -57,38 +57,32 @@ func TestAccDataSourceItemLoginFailsOnWrongResourceType(t *testing.T) {
 }
 
 func TestAccDataSourceItemLoginBySearch(t *testing.T) {
-	resourceName := "bitwarden_item_login.foo"
-
 	ensureVaultwardenConfigured(t)
 
 	resource.UnitTest(t, resource.TestCase{
 		ProviderFactories: providerFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: tfConfigProvider() + tfConfigResourceFolder() + tfConfigResourceItemLogin(),
-				Check:  checkItemLogin(resourceName),
-			},
-			{
-				Config: tfConfigProvider() + tfConfigResourceFolder() + tfConfigResourceItemLogin() + tfConfigDataItemLoginWithSearchAndOrg("test-username"),
+				Config: tfConfigProvider() + tfConfigResourceItemLogin() + tfConfigDataItemLoginWithSearchAndOrg("test-username"),
 				Check:  checkItemLogin("data.bitwarden_item_login.foo_data"),
 			},
 			{
-				Config: tfConfigProvider() + tfConfigResourceFolder() + tfConfigResourceItemLogin() + tfConfigResourceItemLoginDuplicate() + tfConfigDataItemLoginWithSearchAndOrg("test-username"),
+				Config: tfConfigProvider() + tfConfigResourceItemLogin() + tfConfigResourceItemLoginDuplicate() + tfConfigDataItemLoginWithSearchAndOrg("test-username"),
 				Check:  checkItemLogin("data.bitwarden_item_login.foo_data"),
 			},
 			{
-				Config:      tfConfigProvider() + tfConfigResourceFolder() + tfConfigResourceItemLogin() + tfConfigResourceItemLoginDuplicate() + tfConfigDataItemLoginWithSearchOnly("test-username"),
+				Config:      tfConfigProvider() + tfConfigResourceItemLogin() + tfConfigResourceItemLoginDuplicate() + tfConfigDataItemLoginWithSearchOnly("test-username"),
 				ExpectError: regexp.MustCompile("Error: too many objects found"),
 			},
 			{
-				Config:      tfConfigProvider() + tfConfigResourceFolder() + tfConfigResourceItemLogin() + tfConfigDataItemLoginWithSearchAndOrg("missing-item"),
+				Config:      tfConfigProvider() + tfConfigResourceItemLogin() + tfConfigDataItemLoginWithSearchAndOrg("missing-item"),
 				ExpectError: regexp.MustCompile("Error: no object found matching the filter"),
 			},
 			{
-				Config: tfConfigProvider() + tfConfigResourceFolder() + tfConfigResourceItemSecureNote(),
+				Config: tfConfigProvider() + tfConfigResourceItemSecureNote(),
 			},
 			{
-				Config:      tfConfigProvider() + tfConfigResourceFolder() + tfConfigResourceItemSecureNote() + tfConfigDataItemLoginWithSearchAndOrg("secure-bar"),
+				Config:      tfConfigProvider() + tfConfigResourceItemSecureNote() + tfConfigDataItemLoginWithSearchAndOrg("secure-bar"),
 				ExpectError: regexp.MustCompile("Error: no object found matching the filter"),
 			},
 		},

--- a/internal/provider/data_source_item_login_test.go
+++ b/internal/provider/data_source_item_login_test.go
@@ -63,6 +63,9 @@ func TestAccDataSourceItemLoginBySearch(t *testing.T) {
 		ProviderFactories: providerFactories,
 		Steps: []resource.TestStep{
 			{
+				Config: tfConfigProvider() + tfConfigResourceItemLogin(),
+			},
+			{
 				Config: tfConfigProvider() + tfConfigResourceItemLogin() + tfConfigDataItemLoginWithSearchAndOrg("test-username"),
 				Check:  checkItemLogin("data.bitwarden_item_login.foo_data"),
 			},

--- a/internal/provider/data_source_item_secure_note_test.go
+++ b/internal/provider/data_source_item_secure_note_test.go
@@ -15,10 +15,10 @@ func TestAccDataSourceItemSecureNote(t *testing.T) {
 		ProviderFactories: providerFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: tfConfigProvider() + tfConfigResourceFolder() + tfConfigResourceItemSecureNote(),
+				Config: tfConfigProvider() + tfConfigResourceItemSecureNote(),
 			},
 			{
-				Config: tfConfigProvider() + tfConfigResourceFolder() + tfConfigResourceItemSecureNote() + tfConfigDataItemSecureNote(),
+				Config: tfConfigProvider() + tfConfigResourceItemSecureNote() + tfConfigDataItemSecureNote(),
 				Check:  checkItemGeneral(resourceName),
 			},
 		},

--- a/internal/provider/data_source_org_collection_test.go
+++ b/internal/provider/data_source_org_collection_test.go
@@ -23,7 +23,7 @@ func TestAccDataSourceOrgCollectionAttributes(t *testing.T) {
 				Config: tfConfigProvider() + tfConfigDataOrgCollection(),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestMatchResourceAttr(
-						resourceName, attributeName, regexp.MustCompile("^coll-([0-9]+)-([0-9]+)-([0-9]+)$"),
+						resourceName, attributeName, regexp.MustCompile("^coll-([0-9]{6})$"),
 					),
 					resource.TestMatchResourceAttr(
 						resourceName, attributeID, regexp.MustCompile(regExpId),

--- a/internal/provider/data_source_organization_test.go
+++ b/internal/provider/data_source_organization_test.go
@@ -23,7 +23,7 @@ func TestAccDataSourceOrganizationAttributes(t *testing.T) {
 				Config: tfConfigProvider() + tfConfigDataOrganization(),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestMatchResourceAttr(
-						resourceName, attributeName, regexp.MustCompile("^org-([0-9]+)-([0-9]+)-([0-9]+)$"),
+						resourceName, attributeName, regexp.MustCompile("^org-([0-9]{6})$"),
 					),
 					resource.TestMatchResourceAttr(
 						resourceName, attributeID, regexp.MustCompile(regExpId),

--- a/internal/provider/provider_bitwarden_client_test.go
+++ b/internal/provider/provider_bitwarden_client_test.go
@@ -162,13 +162,14 @@ func TestProviderRetryOnRateLimitExceeded(t *testing.T) {
 
 	diag := New(versionDev)().Configure(context.Background(), terraform.NewResourceConfigRaw(raw))
 
-	assert.True(t, diag.HasError())
-	assert.Equal(t, diag[0].Summary, "failing command 'status' for test purposes: Rate limit exceeded. Try again later.")
-	assert.Equal(t, []string{
-		"status",
-		"status",
-		"status",
-	}, commandsExecuted())
+	if assert.True(t, diag.HasError()) {
+		assert.Equal(t, diag[0].Summary, "failing command 'status' for test purposes: Rate limit exceeded. Try again later.")
+		assert.Equal(t, []string{
+			"status",
+			"status",
+			"status",
+		}, commandsExecuted())
+	}
 }
 
 func TestProviderReturnUnhandledError(t *testing.T) {
@@ -185,9 +186,10 @@ func TestProviderReturnUnhandledError(t *testing.T) {
 
 	diag := New(versionDev)().Configure(context.Background(), terraform.NewResourceConfigRaw(raw))
 
-	assert.True(t, diag.HasError())
-	assert.Equal(t, diag[0].Summary, "failing command 'status' for test purposes: Something unknown and bad happened.")
-	assert.Equal(t, []string{
-		"status",
-	}, commandsExecuted())
+	if assert.True(t, diag.HasError()) {
+		assert.Equal(t, diag[0].Summary, "failing command 'status' for test purposes: Something unknown and bad happened.")
+		assert.Equal(t, []string{
+			"status",
+		}, commandsExecuted())
+	}
 }

--- a/internal/provider/provider_utils_test.go
+++ b/internal/provider/provider_utils_test.go
@@ -20,6 +20,7 @@ import (
 
 const (
 	// Constants used to interact with a test Vaultwarden instance
+	testUsername  = "test"
 	testEmail     = "test@laverse.net"
 	testPassword  = "test1234"
 	kdfIterations = 10000
@@ -29,6 +30,8 @@ const (
 var testServerURL string
 var testOrganizationID string
 var testCollectionID string
+var testFolderID string
+var testUniqueIdentifier string
 
 // providerFactories are used to instantiate a provider during acceptance testing.
 // The factory function will be invoked for every Terraform CLI command executed
@@ -45,6 +48,8 @@ var isUserCreated bool
 var userMu sync.Mutex
 
 func init() {
+	testUniqueIdentifier = fmt.Sprintf("%02d%02d%02d", time.Now().Hour(), time.Now().Minute(), time.Now().Second())
+
 	host := os.Getenv("VAULTWARDEN_HOST")
 	port := os.Getenv("VAULTWARDEN_PORT")
 
@@ -57,6 +62,20 @@ func init() {
 	testServerURL = fmt.Sprintf("http://%s:%s/", host, port)
 }
 
+func ensureVaultwardenConfigured(t *testing.T) {
+	testResourcesMu.Lock()
+	defer testResourcesMu.Unlock()
+
+	if areTestResourcesCreated {
+		return
+	}
+
+	ensureVaultwardenHasUser(t)
+	createTestOrganization(t)
+	createTestUserResources(t)
+	areTestResourcesCreated = true
+}
+
 func ensureVaultwardenHasUser(t *testing.T) {
 	userMu.Lock()
 	defer userMu.Unlock()
@@ -67,49 +86,57 @@ func ensureVaultwardenHasUser(t *testing.T) {
 
 	webapiClient := webapi.NewClient(testServerURL)
 
-	err := webapiClient.RegisterUser("test", testEmail, testPassword, kdfIterations)
+	err := webapiClient.RegisterUser(testUsername, testEmail, testPassword, kdfIterations)
 	if err != nil && !strings.Contains(strings.ToLower(err.Error()), "user already exists") {
 		t.Fatal(err)
 	}
 	isUserCreated = true
 }
 
-func ensureVaultwardenConfigured(t *testing.T) {
-	testResourcesMu.Lock()
-	defer testResourcesMu.Unlock()
-
-	if areTestResourcesCreated {
-		return
-	}
-
+func createTestOrganization(t *testing.T) {
 	webapiClient := webapi.NewClient(testServerURL)
-
-	userAlreadyExists := false
-	err := webapiClient.RegisterUser("test", testEmail, testPassword, kdfIterations)
-	if err != nil && strings.Contains(err.Error(), "User already exists") {
-		userAlreadyExists = true
-	}
-
-	err = webapiClient.Login(testEmail, testPassword, kdfIterations)
-	if err != nil {
-		if userAlreadyExists {
-			t.Fatalf("Unable to log into test instance, and the user was already present. Try removing it! Error: %v", err)
-		} else {
-			t.Fatal(err)
-		}
-	}
-	dateTimeStr := fmt.Sprintf("%d-%d-%d", time.Now().Hour(), time.Now().Minute(), time.Now().Second())
-	testOrganizationID, err = webapiClient.CreateOrganization(fmt.Sprintf("org-%s", dateTimeStr), fmt.Sprintf("coll-%s", dateTimeStr), testEmail)
+	err := webapiClient.Login(testEmail, testPassword, kdfIterations)
 	if err != nil {
 		t.Fatal(err)
 	}
+
+	organizationName := fmt.Sprintf("org-%s", testUniqueIdentifier)
+	organizationLabel := fmt.Sprintf("coll-%s", testUniqueIdentifier)
+	testOrganizationID, err = webapiClient.CreateOrganization(organizationName, organizationLabel, testEmail)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Logf("Created Organization '%s' (%s)", organizationName, testOrganizationID)
 
 	testCollectionID, err = webapiClient.GetCollections(testOrganizationID)
 	if err != nil {
 		t.Fatal(err)
 	}
+	t.Logf("Retrieved Organization Collection '%s' (%s)", organizationLabel, testOrganizationID)
+}
 
-	areTestResourcesCreated = true
+func createTestUserResources(t *testing.T) {
+	testFolderName := fmt.Sprintf("folder-%s-bar", testUniqueIdentifier)
+	bwClient := bwTestClient(t)
+	folder, err := bwClient.CreateObject(context.Background(), bw.Object{
+		Object: bw.ObjectTypeFolder,
+		Name:   testFolderName,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	testFolderID = folder.ID
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Logf("Created Folder '%s' (%s)", testFolderName, testFolderID)
+
+	err = bwClient.Sync(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Log("Synced Bitwarden client")
 }
 
 func bwTestClient(t *testing.T) bw.Client {
@@ -123,8 +150,29 @@ func bwTestClient(t *testing.T) bw.Client {
 		t.Fatal(err)
 	}
 
-	client := bw.NewClient(bwExec, bw.WithAppDataDir(vault))
-	client.Unlock(context.Background(), testPassword)
+	client := bw.NewClient(bwExec, bw.DisableRetryBackoff(), bw.WithAppDataDir(vault))
+	status, err := client.Status(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(status.ServerURL) == 0 {
+		err = client.SetServer(context.Background(), testServerURL)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	if status.Status == bw.StatusUnauthenticated {
+		err = client.LoginWithPassword(context.Background(), testEmail, testPassword)
+		if err != nil {
+			t.Fatal(err)
+		}
+	} else if status.Status == bw.StatusLocked {
+		err = client.Unlock(context.Background(), testPassword)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
 	return client
 }
 

--- a/internal/provider/provider_utils_test.go
+++ b/internal/provider/provider_utils_test.go
@@ -20,13 +20,13 @@ import (
 
 const (
 	// Constants used to interact with a test Vaultwarden instance
-	testUsername  = "test"
-	testEmail     = "test@laverse.net"
 	testPassword  = "test1234"
 	kdfIterations = 10000
 )
 
 // Generated resources used for testing
+var testEmail string
+var testUsername string
 var testServerURL string
 var testOrganizationID string
 var testCollectionID string
@@ -84,13 +84,23 @@ func ensureVaultwardenHasUser(t *testing.T) {
 		return
 	}
 
-	webapiClient := webapi.NewClient(testServerURL)
+	clearTestVault(t)
 
+	webapiClient := webapi.NewClient(testServerURL)
+	testUsername = fmt.Sprintf("test-%s", testUniqueIdentifier)
+	testEmail = fmt.Sprintf("test-%s@laverse.net", testUniqueIdentifier)
 	err := webapiClient.RegisterUser(testUsername, testEmail, testPassword, kdfIterations)
 	if err != nil && !strings.Contains(strings.ToLower(err.Error()), "user already exists") {
 		t.Fatal(err)
 	}
 	isUserCreated = true
+}
+
+func clearTestVault(t *testing.T) {
+	err := os.Remove(".bitwarden/data.json")
+	if err != nil && !os.IsNotExist(err) {
+		t.Fatal(err)
+	}
 }
 
 func createTestOrganization(t *testing.T) {

--- a/internal/provider/resource_item_login_test.go
+++ b/internal/provider/resource_item_login_test.go
@@ -21,7 +21,7 @@ func TestAccResourceItemLoginAttributes(t *testing.T) {
 		ProviderFactories: providerFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: tfConfigProvider() + tfConfigResourceFolder() + tfConfigResourceItemLogin(),
+				Config: tfConfigProvider() + tfConfigResourceItemLogin(),
 				Check: resource.ComposeTestCheckFunc(
 					checkItemLogin(resourceName),
 					getObjectID(resourceName, &objectID),
@@ -87,7 +87,7 @@ func tfConfigResourceItemLogin() string {
 
 		organization_id     = "%s"
 		collection_ids		= ["%s"]
-		folder_id 			= bitwarden_folder.foo.id
+		folder_id 			= "%s"
 		username 			= "test-username"
 		password 			= "test-password"
 		totp 				= "1234"
@@ -150,7 +150,7 @@ func tfConfigResourceItemLogin() string {
 			value = "https://default"
 		}
 	}
-`, testOrganizationID, testCollectionID)
+`, testOrganizationID, testCollectionID, testFolderID)
 }
 
 func checkItemLogin(resourceName string) resource.TestCheckFunc {

--- a/internal/provider/resource_item_secure_note_test.go
+++ b/internal/provider/resource_item_secure_note_test.go
@@ -17,7 +17,7 @@ func TestAccResourceItemSecureNote(t *testing.T) {
 		ProviderFactories: providerFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: tfConfigProvider() + tfConfigResourceFolder() + tfConfigResourceItemSecureNote(),
+				Config: tfConfigProvider() + tfConfigResourceItemSecureNote(),
 				Check: resource.ComposeTestCheckFunc(
 					checkItemGeneral(resourceName),
 					getObjectID(resourceName, &objectID),
@@ -40,7 +40,7 @@ func tfConfigResourceItemSecureNote() string {
 
 		organization_id     = "%s"
 		collection_ids		= ["%s"]
-		folder_id 			= bitwarden_folder.foo.id
+		folder_id 			= "%s"
 		name     			= "secure-bar"
 		notes 				= "notes"
 		reprompt			= true
@@ -61,5 +61,5 @@ func tfConfigResourceItemSecureNote() string {
 			hidden = "value-hidden"
 		}
 	}
-`, testOrganizationID, testCollectionID)
+`, testOrganizationID, testCollectionID, testFolderID)
 }

--- a/internal/provider/resource_test.go
+++ b/internal/provider/resource_test.go
@@ -15,7 +15,7 @@ const (
 func checkObject(resourceName string) resource.TestCheckFunc {
 	return resource.ComposeTestCheckFunc(
 		resource.TestMatchResourceAttr(
-			resourceName, attributeName, regexp.MustCompile("^([a-z0-9]+)-bar$"),
+			resourceName, attributeName, regexp.MustCompile("^([a-z0-9-]+)-bar$"),
 		),
 		resource.TestMatchResourceAttr(
 			resourceName, attributeID, regexp.MustCompile(regExpId),


### PR DESCRIPTION
Bitwarden CLI commands are slow, and even slower on Github Actions. Create one test folder at the beginning of the run, and use it for subsequent tests.