### PR TITLE
fix login with username/password

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -50,9 +50,9 @@ data "bitwarden_item_login" "example" {
 
 ## Authentication
 The Bitwarden provider can use different combinations of credentials to authenticate:
-* Email and Password (requires `email` and `master_password`)
 * API key (requires `email`, `master_password`, `client_id` and `client_secret`)
-* user-provided Session Key (requires `session_key`)
+* Email and Password (requires `email` and `master_password`) (prefer API keys instead)
+* User-provided Session Key (requires `session_key`) (only works with a pre-downloaded Vault)
 
 ### Generating a Client ID and Secret
 The recommended way to interact with your Vault using the Bitwarden Provider Terraform plugin is to generate an API key.

--- a/internal/bitwarden/crypto/aes_encoding.go
+++ b/internal/bitwarden/crypto/aes_encoding.go
@@ -7,9 +7,8 @@ import (
 	"fmt"
 )
 
-func aes256Decode(cipherText []byte, encKey []byte, iv []byte) ([]byte, error) {
-
-	block, err := aes.NewCipher(encKey)
+func aes256Decode(cipherText []byte, key []byte, iv []byte) ([]byte, error) {
+	block, err := aes.NewCipher(key)
 	if err != nil {
 		return nil, fmt.Errorf("error creating new cipher block: %w", err)
 	}
@@ -23,7 +22,7 @@ func aes256Decode(cipherText []byte, encKey []byte, iv []byte) ([]byte, error) {
 }
 
 func aes256Encode(plainText []byte, key []byte, iv []byte, blockSize int) ([]byte, error) {
-	plainTextPadded := pkcs5Padding([]byte(plainText), blockSize, len(plainText))
+	plainTextPadded := pkcs5Padding([]byte(plainText), blockSize)
 
 	block, err := aes.NewCipher(key)
 	if err != nil {
@@ -51,7 +50,7 @@ func pkcs5Unpadding(src []byte, blockSize int) ([]byte, error) {
 	return src[:srcLen-paddingLen], nil
 }
 
-func pkcs5Padding(cipherText []byte, blockSize int, after int) []byte {
+func pkcs5Padding(cipherText []byte, blockSize int) []byte {
 	padding := (blockSize - len(cipherText)%blockSize)
 	padtext := bytes.Repeat([]byte{byte(padding)}, padding)
 	return append(cipherText, padtext...)

--- a/internal/bitwarden/crypto/helpers/helpers.go
+++ b/internal/bitwarden/crypto/helpers/helpers.go
@@ -1,0 +1,28 @@
+package helpers
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"hash"
+
+	"golang.org/x/crypto/hkdf"
+)
+
+func HMACSum(value, key []byte, algo func() hash.Hash) []byte {
+	mac := hmac.New(algo, key)
+	_, err := mac.Write(value)
+	if err != nil {
+		panic("BUG: hmac.Write should never return an error")
+	}
+	return mac.Sum(nil)
+}
+
+func HKDFExpand(value, key []byte, algo func() hash.Hash, length int) []byte {
+	encKey := hkdf.Expand(sha256.New, value, []byte(key))
+	newEncKey := make([]byte, length)
+	_, err := encKey.Read(newEncKey)
+	if err != nil {
+		panic("BUG: hkdf.Expand should never return an error")
+	}
+	return newEncKey
+}

--- a/internal/bitwarden/embedded/fixtures/create_accounts_test.go
+++ b/internal/bitwarden/embedded/fixtures/create_accounts_test.go
@@ -94,7 +94,7 @@ func createTestAccount(t *testing.T, accountEmail string, kdfConfig models.KdfCo
 			Prefix: mockName,
 		},
 	}
-	vault := embedded.NewPasswordManagerClient(ServerURL, testDeviceIdentifer, embedded.WithHttpOptions(webapi.WithCustomClient(httpClient)))
+	vault := embedded.NewPasswordManagerClient(ServerURL, testDeviceIdentifer, embedded.WithPasswordManagerHttpOptions(webapi.WithCustomClient(httpClient)))
 
 	err = vault.LoginWithPassword(ctx, accountEmail, TestPassword)
 	if err != nil {

--- a/internal/bitwarden/embedded/password_manager_webapi.go
+++ b/internal/bitwarden/embedded/password_manager_webapi.go
@@ -34,11 +34,11 @@ type WebAPIVault interface {
 	Unlock(ctx context.Context, password string) error
 }
 
-type Options func(c bitwarden.PasswordManager)
+type PasswordManagerOptions func(c bitwarden.PasswordManager)
 
 // DisableCryptoSafeMode disables the safe mode for crypto operations, which reverses
 // crypto.Encrypt() to make sure it can decrypt the result.
-func DisableCryptoSafeMode() Options {
+func DisableCryptoSafeMode() PasswordManagerOptions {
 	return func(c bitwarden.PasswordManager) {
 		crypto.SafeMode = false
 	}
@@ -47,7 +47,7 @@ func DisableCryptoSafeMode() Options {
 // DisableObjectEncryptionVerification disables the systematic attempts to decrypt objects
 // (items, folders, collections) after they have been created or edited, to verify that the
 // encryption can be reverse.
-func DisableObjectEncryptionVerification() Options {
+func DisableObjectEncryptionVerification() PasswordManagerOptions {
 	return func(c bitwarden.PasswordManager) {
 		c.(*webAPIVault).baseVault.verifyObjectEncryption = false
 	}
@@ -56,27 +56,26 @@ func DisableObjectEncryptionVerification() Options {
 // DisableSyncAfterWrite disables the systematic Sync() after a write operation (create, edit,
 // delete) to the vault. Write operations already return the object that was created or edited, so
 // Sync() is not strictly necessary.
-func DisableSyncAfterWrite() Options {
+func DisableSyncAfterWrite() PasswordManagerOptions {
 	return func(c bitwarden.PasswordManager) {
 		c.(*webAPIVault).syncAfterWrite = false
 	}
 }
 
-// DisableRetryBackoff disables the retry backoff mechanism for API calls.
-func WithHttpOptions(opts ...webapi.Options) Options {
+func WithPasswordManagerHttpOptions(opts ...webapi.Options) PasswordManagerOptions {
 	return func(c bitwarden.PasswordManager) {
 		c.(*webAPIVault).clientOpts = opts
 	}
 }
 
 // Panic on error is useful for debugging, but should not be used in production.
-func EnablePanicOnEncryptionError() Options {
+func EnablePanicOnEncryptionError() PasswordManagerOptions {
 	return func(c bitwarden.PasswordManager) {
 		panicOnEncryptionErrors = true
 	}
 }
 
-func NewPasswordManagerClient(serverURL, deviceIdentifier string, opts ...Options) WebAPIVault {
+func NewPasswordManagerClient(serverURL, deviceIdentifier string, opts ...PasswordManagerOptions) WebAPIVault {
 	c := &webAPIVault{
 		baseVault: baseVault{
 			objectStore:            make(map[string]models.Object),

--- a/internal/bitwarden/webapi/device.go
+++ b/internal/bitwarden/webapi/device.go
@@ -1,0 +1,67 @@
+package webapi
+
+import (
+	"fmt"
+	"runtime"
+	"strings"
+)
+
+type deviceInfo struct {
+	deviceType       string
+	deviceName       string
+	deviceIdentifier string
+	deviceVersion    string
+	userAgent        string
+}
+
+type deviceInfoWithOfficialFallback struct {
+	deviceInfo
+	official deviceInfo
+}
+
+var (
+	Version = "0.0.1"
+)
+
+func DeviceInformation(deviceId string) deviceInfoWithOfficialFallback {
+	// Bitwarden has a hard-coded list of device types which can be found at:
+	//   => https://github.com/bitwarden/server/blob/main/src/Core/Enums/DeviceType.cs
+	//
+	// Authenticating using username/password is not documented, and seems to be restricted to
+	// the officially recognized devices. To keep a one-to-one feature correspondence between the
+	// CLI and the embedded client, we're going to fake our device information when an API call
+	// requires it, while showing our real identify as often as possible.
+	// Still, we're going to strongly encourage users to rely on the API key authentication, since
+	// it's the only officially supported way to authenticate.
+	var correspondingOfficialDeviceType, correspondingOfficialDeviceName string
+	correspondingOfficialDeviceVersion := "2024.9.0"
+
+	switch os := runtime.GOOS; os {
+	case "windows":
+		correspondingOfficialDeviceType = "23"
+		correspondingOfficialDeviceName = "windows"
+	case "darwin":
+		correspondingOfficialDeviceType = "24"
+		correspondingOfficialDeviceName = "macos"
+	case "linux":
+		correspondingOfficialDeviceType = "25"
+		correspondingOfficialDeviceName = "linux"
+	}
+
+	return deviceInfoWithOfficialFallback{
+		deviceInfo: deviceInfo{
+			deviceType:       "21", // SDK
+			deviceName:       "Bitwarden_Terraform_Provider",
+			deviceIdentifier: deviceId,
+			deviceVersion:    Version,
+			userAgent:        fmt.Sprintf("Bitwarden_Terraform_Provider/%s (%s)", Version, strings.ToUpper(runtime.GOOS)),
+		},
+		official: deviceInfo{
+			deviceType:       correspondingOfficialDeviceType,
+			deviceName:       correspondingOfficialDeviceName,
+			deviceIdentifier: deviceId,
+			deviceVersion:    correspondingOfficialDeviceVersion,
+			userAgent:        fmt.Sprintf("Bitwarden_CLI/%s (%s)", correspondingOfficialDeviceVersion, strings.ToUpper(correspondingOfficialDeviceName)),
+		},
+	}
+}

--- a/internal/provider/data_source.go
+++ b/internal/provider/data_source.go
@@ -9,7 +9,7 @@ import (
 	"github.com/maxlaverse/terraform-provider-bitwarden/internal/bitwarden/models"
 )
 
-func resourceReadDataSourceItem(attrObject models.ObjectType, attrType models.ItemType) resourceOperation {
+func resourceReadDataSourceItem(attrObject models.ObjectType, attrType models.ItemType) passwordManagerOperation {
 	return func(ctx context.Context, d *schema.ResourceData, bwClient bitwarden.PasswordManager) diag.Diagnostics {
 		err := d.Set(attributeType, attrType)
 		if err != nil {
@@ -19,7 +19,7 @@ func resourceReadDataSourceItem(attrObject models.ObjectType, attrType models.It
 	}
 }
 
-func resourceReadDataSourceObject(objType models.ObjectType) resourceOperation {
+func resourceReadDataSourceObject(objType models.ObjectType) passwordManagerOperation {
 	return func(ctx context.Context, d *schema.ResourceData, bwClient bitwarden.PasswordManager) diag.Diagnostics {
 		d.SetId(d.Get(attributeID).(string))
 		err := d.Set(attributeObject, objType)

--- a/internal/provider/resource.go
+++ b/internal/provider/resource.go
@@ -11,7 +11,7 @@ import (
 	"github.com/maxlaverse/terraform-provider-bitwarden/internal/bitwarden/models"
 )
 
-func resourceCreateObject(attrObject models.ObjectType, attrType models.ItemType) resourceOperation {
+func resourceCreateObject(attrObject models.ObjectType, attrType models.ItemType) passwordManagerOperation {
 	return func(ctx context.Context, d *schema.ResourceData, bwClient bitwarden.PasswordManager) diag.Diagnostics {
 		err := d.Set(attributeObject, attrObject)
 		if err != nil {

--- a/internal/provider/resource_item_login.go
+++ b/internal/provider/resource_item_login.go
@@ -1,11 +1,7 @@
 package provider
 
 import (
-	"context"
-
-	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/maxlaverse/terraform-provider-bitwarden/internal/bitwarden"
 	"github.com/maxlaverse/terraform-provider-bitwarden/internal/bitwarden/models"
 )
 
@@ -23,17 +19,5 @@ func resourceItemLogin() *schema.Resource {
 		DeleteContext: withPasswordManager(resourceDeleteObject),
 		Importer:      resourceImporter(resourceImportObject(models.ObjectTypeItem, models.ItemTypeLogin)),
 		Schema:        dataSourceItemSecureNoteSchema,
-	}
-}
-
-type resourceOperation func(ctx context.Context, d *schema.ResourceData, bwClient bitwarden.PasswordManager) diag.Diagnostics
-
-func withPasswordManager(resourceAction resourceOperation) func(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	return func(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-		bwClient, err := getPasswordManager(meta)
-		if err != nil {
-			return diag.FromErr(err)
-		}
-		return resourceAction(ctx, d, bwClient)
 	}
 }

--- a/internal/provider/schema_helpers.go
+++ b/internal/provider/schema_helpers.go
@@ -1,0 +1,22 @@
+package provider
+
+import (
+	"context"
+	"errors"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/maxlaverse/terraform-provider-bitwarden/internal/bitwarden"
+)
+
+type passwordManagerOperation func(ctx context.Context, d *schema.ResourceData, bwClient bitwarden.PasswordManager) diag.Diagnostics
+
+func withPasswordManager(resourceAction passwordManagerOperation) func(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	return func(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+		bwClient, ok := meta.(bitwarden.PasswordManager)
+		if !ok {
+			return diag.FromErr(errors.New("provider was not configured with Password Manager credentials"))
+		}
+		return resourceAction(ctx, d, bwClient)
+	}
+}

--- a/internal/provider/schema_organization.go
+++ b/internal/provider/schema_organization.go
@@ -21,7 +21,7 @@ func organizationSchema() map[string]*schema.Schema {
 			Type:        schema.TypeString,
 			Computed:    true,
 		},
-		attributeFilterSearch: &schema.Schema{
+		attributeFilterSearch: {
 			Description:  descriptionFilterSearch,
 			Type:         schema.TypeString,
 			Optional:     true,

--- a/main.go
+++ b/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/plugin"
+	"github.com/maxlaverse/terraform-provider-bitwarden/internal/bitwarden/webapi"
 	"github.com/maxlaverse/terraform-provider-bitwarden/internal/provider"
 )
 
@@ -20,6 +21,7 @@ var (
 )
 
 func main() {
+	webapi.Version = version
 	opts := &plugin.ServeOpts{ProviderFunc: provider.New(version)}
 
 	plugin.Serve(opts)

--- a/templates/index.md.tmpl
+++ b/templates/index.md.tmpl
@@ -16,9 +16,9 @@ You must configure the provider with proper credentials before you can use it, a
 
 ## Authentication
 The Bitwarden provider can use different combinations of credentials to authenticate:
-* Email and Password (requires `email` and `master_password`)
 * API key (requires `email`, `master_password`, `client_id` and `client_secret`)
-* user-provided Session Key (requires `session_key`)
+* Email and Password (requires `email` and `master_password`) (prefer API keys instead)
+* User-provided Session Key (requires `session_key`) (only works with a pre-downloaded Vault)
 
 ### Generating a Client ID and Secret
 The recommended way to interact with your Vault using the Bitwarden Provider Terraform plugin is to generate an API key.


### PR DESCRIPTION
* encourage users to rely on api keys instead of username/password
* use special header/parameter combination to successfully ho through Bitwarden.com's login