### PR TITLE
support creating attachments directly from content

### DIFF
--- a/docs/resources/attachment.md
+++ b/docs/resources/attachment.md
@@ -18,7 +18,20 @@ resource "bitwarden_item_login" "vpn_credentials" {
   username = "admin"
 }
 
-resource "bitwarden_attachment" "vpn_config" {
+resource "bitwarden_attachment" "vpn_config_from_content" {
+  // NOTE: Only works when the experimental embedded client support is enabled
+  file_name = "vpn-config.txt"
+  content = jsonencode({
+    domain : "laverse.net",
+    persistence : {
+      enabled : true,
+    }
+  })
+
+  item_id = bitwarden_item_login.vpn_credentials.id
+}
+
+resource "bitwarden_attachment" "vpn_config_from_file" {
   file    = "vpn-config.txt"
   item_id = bitwarden_item_login.vpn_credentials.id
 }
@@ -29,12 +42,16 @@ resource "bitwarden_attachment" "vpn_config" {
 
 ### Required
 
-- `file` (String) Path to the content of the attachment.
 - `item_id` (String) Identifier of the item the attachment belongs to
+
+### Optional
+
+- `content` (String) Path to the content of the attachment.
+- `file` (String) Path to the content of the attachment.
+- `file_name` (String) File name
 
 ### Read-Only
 
-- `file_name` (String) File name
 - `id` (String) Identifier.
 - `size` (String) Size in bytes
 - `size_name` (String) Size as string

--- a/docs/resources/project.md
+++ b/docs/resources/project.md
@@ -14,7 +14,7 @@ Manages a Project.
 
 ```terraform
 resource "bitwarden_project" "example" {
-  name        = "Example Project"
+  name = "Example Project"
 }
 ```
 

--- a/examples/resources/bitwarden_attachment/resource.tf
+++ b/examples/resources/bitwarden_attachment/resource.tf
@@ -3,7 +3,20 @@ resource "bitwarden_item_login" "vpn_credentials" {
   username = "admin"
 }
 
-resource "bitwarden_attachment" "vpn_config" {
+resource "bitwarden_attachment" "vpn_config_from_content" {
+  // NOTE: Only works when the experimental embedded client support is enabled
+  file_name = "vpn-config.txt"
+  content = jsonencode({
+    domain : "laverse.net",
+    persistence : {
+      enabled : true,
+    }
+  })
+
+  item_id = bitwarden_item_login.vpn_credentials.id
+}
+
+resource "bitwarden_attachment" "vpn_config_from_file" {
   file    = "vpn-config.txt"
   item_id = bitwarden_item_login.vpn_credentials.id
 }

--- a/examples/resources/bitwarden_project/resource.tf
+++ b/examples/resources/bitwarden_project/resource.tf
@@ -1,3 +1,3 @@
 resource "bitwarden_project" "example" {
-  name        = "Example Project"
+  name = "Example Project"
 }

--- a/internal/bitwarden/bwcli/password_manager.go
+++ b/internal/bitwarden/bwcli/password_manager.go
@@ -13,7 +13,8 @@ import (
 )
 
 type PasswordManagerClient interface {
-	CreateAttachment(ctx context.Context, itemId, filePath string) (*models.Object, error)
+	CreateAttachmentFromFile(ctx context.Context, itemId, filePath string) (*models.Object, error)
+	CreateAttachmentFromContent(ctx context.Context, itemId, filename string, content []byte) (*models.Object, error)
 	CreateObject(context.Context, models.Object) (*models.Object, error)
 	EditObject(context.Context, models.Object) (*models.Object, error)
 	GetAttachment(ctx context.Context, itemId, attachmentId string) ([]byte, error)
@@ -114,7 +115,11 @@ func (c *client) CreateObject(ctx context.Context, obj models.Object) (*models.O
 	return &obj, nil
 }
 
-func (c *client) CreateAttachment(ctx context.Context, itemId string, filePath string) (*models.Object, error) {
+func (c *client) CreateAttachmentFromContent(ctx context.Context, itemId, filename string, content []byte) (*models.Object, error) {
+	return nil, fmt.Errorf("creating attachments from content is only supported by the embedded client")
+}
+
+func (c *client) CreateAttachmentFromFile(ctx context.Context, itemId string, filePath string) (*models.Object, error) {
 	out, err := c.cmdWithSession("create", string(models.ObjectTypeAttachment), "--itemid", itemId, "--file", filePath).Run(ctx)
 	if err != nil {
 		return nil, err

--- a/internal/bitwarden/client.go
+++ b/internal/bitwarden/client.go
@@ -11,7 +11,8 @@ const (
 )
 
 type PasswordManager interface {
-	CreateAttachment(ctx context.Context, itemId, filePath string) (*models.Object, error)
+	CreateAttachmentFromContent(ctx context.Context, itemId, filename string, content []byte) (*models.Object, error)
+	CreateAttachmentFromFile(ctx context.Context, itemId, filePath string) (*models.Object, error)
 	CreateObject(context.Context, models.Object) (*models.Object, error)
 	DeleteAttachment(ctx context.Context, itemId, attachmentId string) error
 	DeleteObject(context.Context, models.Object) error


### PR DESCRIPTION
Fixes https://github.com/maxlaverse/terraform-provider-bitwarden/issues/146

Adds support for creating attachments directly from content instead of file path. The feature is only supported with the embedded client, as the official CLI would require to write the secret file on disk first.