### PR TITLE
fix disable_sync_after_write_verification and collectionIds ignore rule

### DIFF
--- a/internal/bitwarden/embedded/password_manager_base.go
+++ b/internal/bitwarden/embedded/password_manager_base.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"net/url"
-	"path"
 	"regexp"
 	"strings"
 	"sync"
@@ -922,19 +921,13 @@ func verifyDecryptedObject[T any](ctx context.Context, actual, expected T) error
 }
 
 func compareObjects[T any](_ context.Context, actual, expected T, ignoreFields ...string) error {
-	patch, err := jsondiff.Compare(actual, expected)
+	patch, err := jsondiff.Compare(actual, expected, jsondiff.Ignores(ignoreFields...), jsondiff.Equivalent())
 	if err != nil {
 		return fmt.Errorf("error comparing objects: %w", err)
 	}
 
 	differentKeys := []string{}
-Loop:
 	for _, p := range patch {
-		for _, pattern := range ignoreFields {
-			if matched, _ := path.Match(pattern, p.Path); matched {
-				continue Loop
-			}
-		}
 		differentKeys = append(differentKeys, p.Path)
 	}
 	if len(differentKeys) == 0 {

--- a/internal/bitwarden/embedded/password_manager_base_test.go
+++ b/internal/bitwarden/embedded/password_manager_base_test.go
@@ -22,7 +22,7 @@ const (
 	orgUuid = "81cc1652-dc80-472d-909f-9539d057068b"
 )
 
-func TestCompareObjects(t *testing.T) {
+func TestCompareObjectsSimpleKeys(t *testing.T) {
 	obj1 := models.Item{
 		Name: "test",
 	}
@@ -35,6 +35,33 @@ func TestCompareObjects(t *testing.T) {
 	assert.NoError(t, compareObjects(context.Background(), obj1, obj2))
 	assert.EqualError(t, compareObjects(context.Background(), obj1, obj3), "different keys at [/name]")
 	assert.NoError(t, compareObjects(context.Background(), obj1, obj3, "/name"))
+}
+
+func TestCompareObjectsArrays(t *testing.T) {
+	obj1 := models.Item{
+		Name:          "test",
+		CollectionIds: []string{"1"},
+	}
+	obj2 := models.Item{
+		Name:          "test",
+		CollectionIds: []string{"2"},
+	}
+	obj3 := models.Item{
+		Name:          "test1",
+		CollectionIds: nil,
+	}
+	obj4 := models.Item{
+		Name:          "test1",
+		CollectionIds: []string{"1", "2"},
+	}
+	obj5 := models.Item{
+		Name:          "test1",
+		CollectionIds: []string{"2", "1"},
+	}
+	assert.NoError(t, compareObjects(context.Background(), obj1, obj1))
+	assert.EqualError(t, compareObjects(context.Background(), obj1, obj2), "different keys at [/collectionIds/0]")
+	assert.NoError(t, compareObjects(context.Background(), obj3, obj4, "/collectionIds"))
+	assert.NoError(t, compareObjects(context.Background(), obj4, obj5))
 }
 
 func TestMatchUrl(t *testing.T) {

--- a/internal/provider/provider_schema_validation_test.go
+++ b/internal/provider/provider_schema_validation_test.go
@@ -218,3 +218,31 @@ func TestProviderAuth_ThrowsErrorOnMissingServer(t *testing.T) {
 
 	assert.Implements(t, (*bwcli.PasswordManagerClient)(nil), p.Meta())
 }
+
+func TestSyncAfterWriteVerificationDisabled(t *testing.T) {
+	raw := map[string]interface{}{
+		"server":          "http://127.0.0.1/",
+		"email":           "test@laverse.net",
+		"client_id":       "client-id-1234",
+		"client_secret":   "client-secret-5678",
+		"master_password": "master-password-9",
+		"experimental": []interface{}{
+			map[string]interface{}{
+				"embedded_client":                       "true",
+				"disable_sync_after_write_verification": "true",
+			},
+		},
+	}
+
+	p := New(versionTestSkippedLogin)()
+
+	config := terraform.NewResourceConfigRaw(raw)
+	diag := p.Validate(config)
+	assert.False(t, diag.HasError())
+
+	diag = p.Configure(context.Background(), config)
+	assert.False(t, diag.HasError())
+
+	assert.Implements(t, (*embedded.PasswordManagerClient)(nil), p.Meta())
+	assert.True(t, p.Meta().(embedded.PasswordManagerClient).IsSyncAfterWriteVerificationDisabled())
+}


### PR DESCRIPTION
Fix the incorrect check whether or not `disable_sync_after_write_verification` is enabled, which was effectively making it inoperative. Also, change the field verification rule on CreateItem to ignore missing `collectionIds` instead of missing IDs.