### PR TITLE
Export member manage attribute branch enhanced to add group support

### DIFF
--- a/docs/data-sources/org_collection.md
+++ b/docs/data-sources/org_collection.md
@@ -80,11 +80,23 @@ resource "bitwarden_org_collection" "my_collection" {
 
 ### Read-Only
 
-- `member` (Set of Object) [Experimental] Member of a collection. (see [below for nested schema](#nestedatt--member))
+- `member` (Set of Object) [Experimental] Member (Users) of a collection. (see [below for nested schema](#nestedatt--member))
+- `member_group` (Set of Object) [Experimental] Member Groups of a collection. (see [below for nested schema](#nestedatt--member_group))
 - `name` (String) Name.
 
 <a id="nestedatt--member"></a>
 ### Nested Schema for `member`
+
+Read-Only:
+
+- `hide_passwords` (Boolean)
+- `id` (String)
+- `manage` (Boolean)
+- `read_only` (Boolean)
+
+
+<a id="nestedatt--member_group"></a>
+### Nested Schema for `member_group`
 
 Read-Only:
 

--- a/docs/resources/org_collection.md
+++ b/docs/resources/org_collection.md
@@ -13,8 +13,18 @@ Manages an organization collection.
 ## Example Usage
 
 ```terraform
+variable "BW_GROUP_ID" {
+  type        = string
+  description = "Static UUID for a Bitwarden Group"
+}
+
 data "bitwarden_organization" "terraform" {
   search = "Terraform"
+}
+
+data "bitwarden_org_member" "john" {
+  email           = "john@example.com"
+  organization_id = data.bitwarden_organization.terraform.id
 }
 
 resource "bitwarden_org_collection" "infrastructure" {
@@ -27,7 +37,16 @@ resource "bitwarden_org_collection" "generated" {
   organization_id = data.bitwarden_organization.terraform.id
 
   member {
-    email = "devops@example.com"
+    id             = data.bitwarden_org_member.john.id
+    hide_passwords = false
+    read_only      = false
+    manage         = true
+  }
+  member_group {
+    id             = var.BW_GROUP_ID
+    hide_passwords = false
+    read_only      = false
+    manage         = true
   }
 }
 ```
@@ -43,14 +62,29 @@ resource "bitwarden_org_collection" "generated" {
 ### Optional
 
 - `id` (String) Identifier.
-- `member` (Block Set) [Experimental] Member of a collection. (see [below for nested schema](#nestedblock--member))
+- `member` (Block Set) [Experimental] Member (Users) of a collection. (see [below for nested schema](#nestedblock--member))
+- `member_group` (Block Set) [Experimental] Member Groups of a collection. (see [below for nested schema](#nestedblock--member_group))
 
 <a id="nestedblock--member"></a>
 ### Nested Schema for `member`
 
 Required:
 
-- `id` (String) Identifier.
+- `id` (String) [Experimental] Unique Identifier (UUID) of the user or group member.
+
+Optional:
+
+- `hide_passwords` (Boolean) [Experimental] Hide passwords.
+- `manage` (Boolean) [Experimental] Can manage the collection.
+- `read_only` (Boolean) [Experimental] Read/Write permissions.
+
+
+<a id="nestedblock--member_group"></a>
+### Nested Schema for `member_group`
+
+Required:
+
+- `id` (String) [Experimental] Unique Identifier (UUID) of the user or group member.
 
 Optional:
 

--- a/examples/resources/bitwarden_org_collection/resource.tf
+++ b/examples/resources/bitwarden_org_collection/resource.tf
@@ -1,5 +1,15 @@
+variable "BW_GROUP_ID" {
+  type        = string
+  description = "Static UUID for a Bitwarden Group"
+}
+
 data "bitwarden_organization" "terraform" {
   search = "Terraform"
+}
+
+data "bitwarden_org_member" "john" {
+  email           = "john@example.com"
+  organization_id = data.bitwarden_organization.terraform.id
 }
 
 resource "bitwarden_org_collection" "infrastructure" {
@@ -12,6 +22,16 @@ resource "bitwarden_org_collection" "generated" {
   organization_id = data.bitwarden_organization.terraform.id
 
   member {
-    email = "devops@example.com"
+    id             = data.bitwarden_org_member.john.id
+    hide_passwords = false
+    read_only      = false
+    manage         = true
+  }
+  member_group {
+    id             = var.BW_GROUP_ID
+    hide_passwords = false
+    read_only      = false
+    manage         = true
   }
 }
+

--- a/internal/bitwarden/bwcli/password_manager.go
+++ b/internal/bitwarden/bwcli/password_manager.go
@@ -129,8 +129,7 @@ func (c *client) CreateItem(ctx context.Context, obj models.Item) (*models.Item,
 }
 
 func (c *client) CreateOrganizationCollection(ctx context.Context, obj models.OrgCollection) (*models.OrgCollection, error) {
-	obj.Groups = []interface{}{}
-	if len(obj.Users) > 0 {
+	if len(obj.Users) > 0 || len(obj.Groups) > 0 {
 		return nil, fmt.Errorf("managing collection memberships is only supported by the embedded client")
 	}
 	return createObject(ctx, c, obj, models.ObjectTypeOrgCollection)
@@ -176,8 +175,7 @@ func (c *client) EditItem(ctx context.Context, obj models.Item) (*models.Item, e
 }
 
 func (c *client) EditOrganizationCollection(ctx context.Context, obj models.OrgCollection) (*models.OrgCollection, error) {
-	obj.Groups = []interface{}{}
-	if len(obj.Users) > 0 {
+	if len(obj.Users) > 0 || len(obj.Groups) > 0 {
 		return nil, fmt.Errorf("managing collection memberships is only supported by the embedded client")
 	}
 	return editGenericObject(ctx, c, obj, obj.Object, obj.ID)

--- a/internal/bitwarden/embedded/password_manager_base.go
+++ b/internal/bitwarden/embedded/password_manager_base.go
@@ -495,10 +495,6 @@ func encryptOrgCollection(ctx context.Context, obj models.OrgCollection, secret 
 			return nil, fmt.Errorf("error decrypting collection for verification: %w", err)
 		}
 
-		tflog.Info(ctx, fmt.Sprintf("DIFF objects"), map[string]interface{}{
-			"orig":      obj,
-			"decrypted": *actualObj,
-		})
 		err = verifyDecryptedObject(ctx, obj, *actualObj)
 		if err != nil {
 			return nil, fmt.Errorf("error verifying collection after encryption: %w", err)
@@ -940,6 +936,12 @@ func matchHost(url1, url2 string) (bool, error) {
 
 func verifyDecryptedObject[T any](ctx context.Context, actual, expected T) error {
 	err := compareObjects(ctx, actual, expected)
+	if err != nil {
+		tflog.Trace(ctx, fmt.Sprintf("verifyDecryptedObject: error object details."), map[string]interface{}{
+			"actual":   actual,
+			"expected": expected,
+		})
+	}
 	if err != nil && panicOnEncryptionErrors {
 		panic(err)
 	} else if err != nil {

--- a/internal/bitwarden/embedded/password_manager_base_test.go
+++ b/internal/bitwarden/embedded/password_manager_base_test.go
@@ -417,6 +417,7 @@ func testFullyFilledOrgCollection() models.OrgCollection {
 		Object:         models.ObjectTypeOrgCollection,
 		OrganizationID: orgUuid,
 		Users:          []models.OrgCollectionMember{},
+		Groups:         []models.OrgCollectionMember{},
 	}
 	return obj
 }

--- a/internal/bitwarden/embedded/password_manager_webapi.go
+++ b/internal/bitwarden/embedded/password_manager_webapi.go
@@ -345,9 +345,13 @@ func (v *webAPIVault) ensureUsersLoadedForOrg(ctx context.Context, orgId string)
 func (v *webAPIVault) CreateOrganizationCollection(ctx context.Context, obj models.OrgCollection) (*models.OrgCollection, error) {
 	// ValidateFunc is not supported on TypeSet, which means we can't check for
 	// duplicate during Schema validation. Doing it here instead.
-	err := checkForDuplicateMembers(obj.Users)
-	if err != nil {
-		return nil, err
+	userErr := checkForDuplicateMembers(obj.Users)
+	if userErr != nil {
+		return nil, userErr
+	}
+	groupErr := checkForDuplicateMembers(obj.Groups)
+	if groupErr != nil {
+		return nil, groupErr
 	}
 
 	v.vaultOperationMutex.Lock()
@@ -357,7 +361,7 @@ func (v *webAPIVault) CreateOrganizationCollection(ctx context.Context, obj mode
 		return nil, models.ErrVaultLocked
 	}
 
-	manageMembership := len(obj.Users) > 0
+	manageMembership := len(obj.Users) > 0 || len(obj.Groups) > 0
 
 	encObj, err := encryptOrgCollection(ctx, obj, v.loginAccount.Secrets, v.verifyObjectEncryption)
 	if err != nil {
@@ -412,9 +416,13 @@ func (v *webAPIVault) CreateOrganizationCollection(ctx context.Context, obj mode
 func (v *webAPIVault) EditOrganizationCollection(ctx context.Context, obj models.OrgCollection) (*models.OrgCollection, error) {
 	// ValidateFunc is not supported on TypeSet, which means we can't check for
 	// duplicate during Schema validation. Doing it here instead.
-	err := checkForDuplicateMembers(obj.Users)
-	if err != nil {
-		return nil, err
+	userErr := checkForDuplicateMembers(obj.Users)
+	if userErr != nil {
+		return nil, userErr
+	}
+	groupErr := checkForDuplicateMembers(obj.Groups)
+	if groupErr != nil {
+		return nil, groupErr
 	}
 
 	v.vaultOperationMutex.Lock()
@@ -432,7 +440,7 @@ func (v *webAPIVault) EditOrganizationCollection(ctx context.Context, obj models
 	}
 
 	manageMembership := currentObj.Manage
-	if !manageMembership && len(obj.Users) > 0 {
+	if !manageMembership && (len(obj.Users) > 0 || len(obj.Groups) > 0) {
 		return nil, fmt.Errorf("error editing collection: you need to have the Manage permission to edit memberships")
 	}
 

--- a/internal/bitwarden/embedded/testhelper_fixtures_create_test.go
+++ b/internal/bitwarden/embedded/testhelper_fixtures_create_test.go
@@ -152,6 +152,7 @@ func createOrganizationResources(t *testing.T, account1 string, orgId string) {
 		Name:           "org-collection",
 		OrganizationID: orgId,
 		Users:          []models.OrgCollectionMember{},
+		Groups:         []models.OrgCollectionMember{},
 	})
 	if err != nil {
 		t.Fatal(err)

--- a/internal/bitwarden/models/password_manager.go
+++ b/internal/bitwarden/models/password_manager.go
@@ -207,6 +207,6 @@ type OrgCollection struct {
 	Object         ObjectType            `json:"object,omitempty"`
 	OrganizationID string                `json:"organizationId"`
 	Users          []OrgCollectionMember `json:"users"`
-	Groups         []interface{}         `json:"groups"` // Required but not used when creating collections using the CLI
+	Groups         []OrgCollectionMember `json:"groups"` // Required but not used when creating collections using the CLI
 	Manage         bool                  `json:"-"`
 }

--- a/internal/bitwarden/webapi/models.go
+++ b/internal/bitwarden/webapi/models.go
@@ -38,7 +38,7 @@ type CreateObjectAttachmentResponse struct {
 	Url            string            `json:"url"`
 }
 
-type CollectionUser struct {
+type CollectionMember struct {
 	HidePasswords bool   `json:"hidePasswords"`
 	Id            string `json:"id"`
 	ReadOnly      bool   `json:"readOnly"`
@@ -168,18 +168,18 @@ type CollectionResponseItem struct {
 }
 
 type Collection struct {
-	Assigned       bool              `json:"assigned"`
-	ExternalId     string            `json:"externalId"`
-	Groups         []string          `json:"groups"`
-	HidePasswords  bool              `json:"hidePasswords"` // Missing in get collections
-	Id             string            `json:"id"`
-	Manage         bool              `json:"manage"`
-	Name           string            `json:"name"`
-	Object         models.ObjectType `json:"object"`
-	OrganizationId string            `json:"organizationId"`
-	ReadOnly       bool              `json:"readOnly"` // Missing in get collections
-	Unmanaged      bool              `json:"unmanaged"`
-	Users          []CollectionUser  `json:"users"`
+	Assigned       bool               `json:"assigned"`
+	ExternalId     string             `json:"externalId"`
+	Groups         []CollectionMember `json:"groups"`
+	HidePasswords  bool               `json:"hidePasswords"` // Missing in get collections
+	Id             string             `json:"id"`
+	Manage         bool               `json:"manage"`
+	Name           string             `json:"name"`
+	Object         models.ObjectType  `json:"object"`
+	OrganizationId string             `json:"organizationId"`
+	ReadOnly       bool               `json:"readOnly"` // Missing in get collections
+	Unmanaged      bool               `json:"unmanaged"`
+	Users          []CollectionMember `json:"users"`
 }
 
 type CreateCipherRequest struct {

--- a/internal/schema_definition/org_collection.go
+++ b/internal/schema_definition/org_collection.go
@@ -57,7 +57,7 @@ func membershipElem() *schema.Resource {
 	return &schema.Resource{
 		Schema: map[string]*schema.Schema{
 			AttributeID: {
-				Description: DescriptionIdentifier,
+				Description: DescriptionCollectionMemberID,
 				Type:        schema.TypeString,
 				Required:    true,
 			},

--- a/internal/schema_definition/org_collection.go
+++ b/internal/schema_definition/org_collection.go
@@ -31,6 +31,14 @@ func OrgCollectionSchema(schemaType schemaTypeEnum) map[string]*schema.Schema {
 			Optional:    schemaType == Resource,
 			Sensitive:   false,
 		},
+		AttributeMemberGroup: {
+			Description: DescriptionCollectionMemberGroup,
+			Type:        schema.TypeSet,
+			Elem:        membershipElem(),
+			Computed:    schemaType == DataSource,
+			Optional:    schemaType == Resource,
+			Sensitive:   false,
+		},
 	}
 
 	if schemaType == DataSource {

--- a/internal/schema_definition/schema_attributes.go
+++ b/internal/schema_definition/schema_attributes.go
@@ -57,6 +57,7 @@ const (
 	DescriptionCollectionIDs                 = "Identifier of the collections the item belongs to."
 	DescriptionCollectionMember              = "[Experimental] Member (Users) of a collection."
 	DescriptionCollectionMemberGroup         = "[Experimental] Member Groups of a collection."
+	DescriptionCollectionMemberID            = "[Experimental] Unique Identifier (UUID) of the user or group member."
 	DescriptionCollectionMemberReadOnly      = "[Experimental] Read/Write permissions."
 	DescriptionCollectionMemberHidePasswords = "[Experimental] Hide passwords."
 	DescriptionCollectionMemberManage        = "[Experimental] Can manage the collection."

--- a/internal/schema_definition/schema_attributes.go
+++ b/internal/schema_definition/schema_attributes.go
@@ -39,6 +39,7 @@ const (
 	AttributeLoginURIsValue                = "value"
 	AttributeLoginTotp                     = "totp"
 	AttributeMember                        = "member"
+	AttributeMemberGroup                   = "member_group"
 	AttributeName                          = "name"
 	AttributeNotes                         = "notes"
 	AttributeOrganizationID                = "organization_id"
@@ -54,7 +55,8 @@ const (
 	// Data-source and Resource field descriptions
 	DescriptionAttachments                   = "List of item attachments."
 	DescriptionCollectionIDs                 = "Identifier of the collections the item belongs to."
-	DescriptionCollectionMember              = "[Experimental] Member of a collection."
+	DescriptionCollectionMember              = "[Experimental] Member (Users) of a collection."
+	DescriptionCollectionMemberGroup         = "[Experimental] Member Groups of a collection."
 	DescriptionCollectionMemberReadOnly      = "[Experimental] Read/Write permissions."
 	DescriptionCollectionMemberHidePasswords = "[Experimental] Hide passwords."
 	DescriptionCollectionMemberManage        = "[Experimental] Can manage the collection."

--- a/internal/transformation/org_collection.go
+++ b/internal/transformation/org_collection.go
@@ -37,10 +37,28 @@ func OrganizationCollectionObjectToSchema(ctx context.Context, obj *models.OrgCo
 		}
 	}
 
-	set := schema.NewSet(func(i interface{}) int {
+	userSet := schema.NewSet(func(i interface{}) int {
 		return hashStringToInt(i.(map[string]interface{})[schema_definition.AttributeID].(string))
 	}, users)
-	err = d.Set(schema_definition.AttributeMember, set)
+	err = d.Set(schema_definition.AttributeMember, userSet)
+	if err != nil {
+		return err
+	}
+
+	groups := make([]interface{}, len(obj.Groups))
+	for k, v := range obj.Groups {
+		groups[k] = map[string]interface{}{
+			schema_definition.AttributeCollectionMemberHidePasswords: v.HidePasswords,
+			schema_definition.AttributeID:                            v.Id,
+			schema_definition.AttributeCollectionMemberReadOnly:      v.ReadOnly,
+			schema_definition.AttributeCollectionMemberManage:        v.Manage,
+		}
+	}
+
+	groupSet := schema.NewSet(func(i interface{}) int {
+		return hashStringToInt(i.(map[string]interface{})[schema_definition.AttributeID].(string))
+	}, groups)
+	err = d.Set(schema_definition.AttributeMemberGroup, groupSet)
 	if err != nil {
 		return err
 	}
@@ -66,6 +84,18 @@ func OrganizationCollectionToObject(ctx context.Context, d *schema.ResourceData)
 		obj.Users = make([]models.OrgCollectionMember, v.Len())
 		for k, v2 := range v.List() {
 			obj.Users[k] = models.OrgCollectionMember{
+				HidePasswords: v2.(map[string]interface{})[schema_definition.AttributeCollectionMemberHidePasswords].(bool),
+				Id:            v2.(map[string]interface{})[schema_definition.AttributeID].(string),
+				ReadOnly:      v2.(map[string]interface{})[schema_definition.AttributeCollectionMemberReadOnly].(bool),
+				Manage:        v2.(map[string]interface{})[schema_definition.AttributeCollectionMemberManage].(bool),
+			}
+		}
+	}
+
+	if v, ok := d.Get(schema_definition.AttributeMemberGroup).(*schema.Set); ok {
+		obj.Groups = make([]models.OrgCollectionMember, v.Len())
+		for k, v2 := range v.List() {
+			obj.Groups[k] = models.OrgCollectionMember{
 				HidePasswords: v2.(map[string]interface{})[schema_definition.AttributeCollectionMemberHidePasswords].(bool),
 				Id:            v2.(map[string]interface{})[schema_definition.AttributeID].(string),
 				ReadOnly:      v2.(map[string]interface{})[schema_definition.AttributeCollectionMemberReadOnly].(bool),


### PR DESCRIPTION
After learning how the provider works as part of the SSH key upload experiments, I felt confident about going in and extending the embedded client to properly deserialize the group responses.

I originally was just going to update that, but I determined it would be pretty easy to add rudimentary group support as well.

This pull request has the following:
- Patches to update the embedded client to handle and deserialize group objects. (they have the exact same format as the `CollectionMember` user objects.)
- Initial implementation to handle group configuration via `member_group` `AttributeMemberGroup` attribute. This is effectively a carbon-copy if the `member` attribute, but needs group IDs instead of User IDs.
- Doc/example updates (docs pre-patch were incorrect for base member - had email instead of ID.)

What still needs to be done:
- Unit test updates - I tried, but I don't understand your test setup well enough. I did put [example code I used to test this here](https://github.com/ebob9/bw_org_collection_test).
- Data source for group search/query similar to `bitwarden_org_member` (`bitwarden_org_member_group`?). I didn't understand this well enough yet as it's not well documented.

Hope this is helpful, let me know if you need any changes!