### PR TITLE
use persistent device identifier

### DIFF
--- a/.github/actions/setup-test/action.yml
+++ b/.github/actions/setup-test/action.yml
@@ -27,6 +27,10 @@ inputs:
     required: false
     default: '1.11.4'
     type: string
+  deviceIdentifier:
+    description: 'Device Identifier'
+    required: false
+    type: string
 
 runs:
   using: "composite"
@@ -77,3 +81,11 @@ runs:
         shell: bash
         run: |
           go install github.com/magefile/mage@v1.15.0
+
+      - name: Store Device Identifier
+        if: ${{ inputs.deviceIdentifier }}
+        shell: bash
+        run: |
+          mkdir -p ./internal/provider/.bitwarden
+          echo -ne "${{ inputs.deviceIdentifier }}" > ./internal/provider/.bitwarden/device_identifier
+

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -136,6 +136,8 @@ jobs:
       - name: Check out repository code
         uses: actions/checkout@v3
       - uses: ./.github/actions/setup-test
+        with:
+          deviceIdentifier: ${{ secrets.BITWARDEN_DEVICE_IDENTIFIER }}
       - name: Run tests
         run: mage test:integrationPwdOfficialWithEmbeddedClient
         env:
@@ -161,6 +163,8 @@ jobs:
       - name: Check out repository code
         uses: actions/checkout@v3
       - uses: ./.github/actions/setup-test
+        with:
+          deviceIdentifier: ${{ secrets.BWS_DEVICE_IDENTIFIER }}
       - name: Run tests
         run: mage test:integrationBwsOfficial
         env:


### PR DESCRIPTION
Use a constant device identifier to prevent receiving emails every time a workflow runs.