### PR TITLE
support retrying when temporary unavailable

### DIFF
--- a/internal/bitwarden/webapi/client.go
+++ b/internal/bitwarden/webapi/client.go
@@ -21,7 +21,7 @@ import (
 )
 
 const (
-	defaultRequestTimeout = 120 * time.Second
+	defaultRequestTimeout = 10 * time.Second
 	maxConcurrentRequests = 4
 	maxRetryAttempts      = 3
 )

--- a/internal/bitwarden/webapi/retry_round_tripper.go
+++ b/internal/bitwarden/webapi/retry_round_tripper.go
@@ -9,6 +9,7 @@ import (
 	"math"
 	"net"
 	"net/http"
+	"slices"
 	"strconv"
 	"time"
 
@@ -21,17 +22,30 @@ type RetryRoundTripper struct {
 	Transport      http.RoundTripper
 
 	concurrentRequestsSem *semaphore.Weighted
-	maxLowLevelRetries    int
+	maxRetries            int
 	requestTimeout        time.Duration
 }
 
-// maxLowLevelRetries is the maximum number of retries for low-level errors (e.g. timeouts).
-// A value of 0 means no retries.
-func NewRetryRoundTripper(maxConcurrentRequests int, maxLowLevelRetries int, requestTimeout time.Duration) *RetryRoundTripper {
+// List of status codes that are considered retryable depending on the method.
+var retryableStatusCodes = []int{
+	http.StatusTooManyRequests,
+	http.StatusServiceUnavailable,
+}
+
+var retryBackoffFactor = 2
+
+// NewRetryRoundTripper creates a new retry-capable HTTP transport.
+//
+// Parameters:
+//   - maxConcurrentRequests: Maximum number of concurrent requests allowed
+//   - maxRetries: Maximum number of retries for low-level errors (e.g. timeouts) and
+//     bad status codes (e.g. 503). A value of 0 means no retries.
+//   - requestTimeout: Timeout duration that applies to individual request attempts
+func NewRetryRoundTripper(maxConcurrentRequests int, maxRetries int, requestTimeout time.Duration) *RetryRoundTripper {
 	return &RetryRoundTripper{
 		Transport:             http.DefaultTransport,
 		concurrentRequestsSem: semaphore.NewWeighted(int64(maxConcurrentRequests)),
-		maxLowLevelRetries:    maxLowLevelRetries,
+		maxRetries:            maxRetries,
 		requestTimeout:        requestTimeout,
 	}
 }
@@ -58,24 +72,29 @@ func (rrt *RetryRoundTripper) RoundTrip(httpReq *http.Request) (*http.Response, 
 	}
 }
 
-func (rrt *RetryRoundTripper) doRequest(ctx context.Context, httpReq *http.Request, attemptNumber int) (*http.Response, bool, error) {
-	ctx, cancel := context.WithTimeout(ctx, rrt.requestTimeout)
+func (rrt *RetryRoundTripper) doRequest(originalCtx context.Context, httpReq *http.Request, attemptNumber int) (*http.Response, bool, error) {
+	reqCtx, cancel := context.WithTimeout(originalCtx, rrt.requestTimeout)
 	defer cancel()
 
-	resp, err := rrt.Transport.RoundTrip(httpReq.WithContext(ctx))
+	resp, err := rrt.Transport.RoundTrip(httpReq.WithContext(reqCtx))
 
-	// Successfully got an HTTP response that is not a 429
-	if err == nil && resp.StatusCode != http.StatusTooManyRequests {
-		// We read the body as we're cancelling the context when leaving the function.
-		body, err := io.ReadAll(resp.Body)
-		resp.Body.Close()
-		if err != nil {
-			return resp, false, fmt.Errorf("failed to read response body in round tripper: %w", err)
+	isSuccessful := err == nil && !slices.Contains(retryableStatusCodes, resp.StatusCode)
+
+	// If the request was successful, we return without additional logging.
+	// We preserve the response body as exiting the method cancels the context.
+	if isSuccessful {
+		if readErr := preserveResponseBody(resp); readErr != nil {
+			return resp, false, fmt.Errorf("%w (and additionally %w)", err, readErr)
 		}
-
-		resp.Body = io.NopCloser(bytes.NewReader(body))
-		return resp, false, nil
+		return resp, false, err
 	}
+
+	// At this point, there was a problem. We need to check if it's retryable,
+	// and we want to log information in any case.
+	isDialError := err != nil && isDialError(err)
+	isRetriableHttpStatusCode := httpReq.Method == http.MethodGet && err == nil && slices.Contains(retryableStatusCodes, resp.StatusCode)
+	isRetriableReadTimeout := httpReq.Method == http.MethodGet && (isReadTimeout(err))
+	isLastPossibleAttempt := attemptNumber >= rrt.maxRetries-1
 
 	debugInfo := map[string]interface{}{
 		"url":            httpReq.URL.RequestURI(),
@@ -84,53 +103,61 @@ func (rrt *RetryRoundTripper) doRequest(ctx context.Context, httpReq *http.Reque
 		"is_retryable":   false,
 	}
 
-	// Got a low-level error, or a 429 HTTP response. We're returning the error
-	// so let's not log anything additional.
-	if err != nil && !rrt.isRetryableError(err, attemptNumber, httpReq.Method) {
-		tflog.Info(ctx, "retry_round_tripper", debugInfo)
-		return nil, false, err
+	// If the request is not retryable, we preserve the response body, log and return.
+	if isLastPossibleAttempt || (!isDialError && !isRetriableHttpStatusCode && !isRetriableReadTimeout) {
+		tflog.Info(originalCtx, "retry_round_tripper", debugInfo)
+		readErr := preserveResponseBody(resp)
+		if readErr != nil {
+			err = fmt.Errorf("%w (and additionally %w)", err, readErr)
+		}
+		return resp, false, err
 	}
 
-	// Retryable request that had a response. A body is present, throw it away.
-	io.ReadAll(resp.Body)
-	resp.Body.Close()
-
-	var waitDuration time.Duration
 	debugInfo["is_retryable"] = true
+
+	// We're going to retry the request, and therefore should throw away the
+	// response body of the previous attempt if it exists.
+	if resp != nil && resp.Body != nil {
+		io.ReadAll(resp.Body)
+		resp.Body.Close()
+	}
 
 	if err != nil {
 		debugInfo["error"] = err
-		waitDuration = backoff(attemptNumber)
-	} else if resp.StatusCode == http.StatusTooManyRequests {
+	}
+	if resp != nil {
 		debugInfo["status_code"] = resp.StatusCode
 		debugInfo["status_message"] = resp.Status
+	}
+
+	// Try to find the best waiting duration, either from the response headers
+	// or from the backoff function.
+	var waitDuration time.Duration
+	if resp != nil && resp.StatusCode == http.StatusTooManyRequests {
 		waitDuration = tryToReadWaitDurationFromHeaders(resp)
+	} else {
+		waitDuration = backoff(attemptNumber)
 	}
 
 	debugInfo["wait_duration_sec"] = waitDuration.Seconds()
-	tflog.Info(ctx, "retry_round_tripper", debugInfo)
+	tflog.Info(originalCtx, "retry_round_tripper", debugInfo)
 
-	return resp, true, sleepWithContext(ctx, waitDuration)
-}
-
-func (rrt *RetryRoundTripper) isRetryableError(err error, attemptNumber int, httpMethod string) bool {
-	if err == nil {
-		return false
-	}
-
-	if attemptNumber >= rrt.maxLowLevelRetries-1 {
-		return false
-	}
-	if isConnectTimeout(err) {
-		return true
-	}
-	if isReadTimeout(err) && httpMethod == http.MethodGet {
-		return true
-	}
-	return false
+	return resp, true, sleepWithContext(originalCtx, waitDuration)
 }
 
 func tryToReadWaitDurationFromHeaders(resp *http.Response) time.Duration {
+	rateLimitResetRaw := resp.Header.Get("X-Rate-Limit-Reset")
+
+	if len(rateLimitResetRaw) != 0 {
+		resetTime, err := time.Parse(time.RFC3339Nano, rateLimitResetRaw)
+		if err == nil {
+			waitDuration := time.Until(resetTime)
+			if waitDuration > 0 {
+				return waitDuration
+			}
+		}
+	}
+
 	retryAfterRaw := resp.Header.Get("X-Retry-After")
 	if len(retryAfterRaw) != 0 {
 		retryAfter, err := strconv.ParseInt(retryAfterRaw, 10, 64)
@@ -141,9 +168,9 @@ func tryToReadWaitDurationFromHeaders(resp *http.Response) time.Duration {
 	return 0
 }
 
-func isConnectTimeout(err error) bool {
+func isDialError(err error) bool {
 	var netErr net.Error
-	if errors.As(err, &netErr) && netErr.Timeout() {
+	if errors.As(err, &netErr) {
 		opErr, ok := netErr.(*net.OpError)
 		if ok && opErr.Op == "dial" {
 			return true
@@ -165,7 +192,7 @@ func isReadTimeout(err error) bool {
 
 func backoff(attempt int) time.Duration {
 	maxInterval := 30 * time.Second
-	delay := time.Duration(math.Pow(2, float64(attempt))) * time.Second
+	delay := time.Duration(math.Pow(float64(retryBackoffFactor), float64(attempt))) * time.Second
 	if delay > maxInterval {
 		delay = maxInterval
 	}
@@ -180,4 +207,20 @@ func sleepWithContext(ctx context.Context, duration time.Duration) error {
 	case <-time.After(duration):
 		return nil
 	}
+}
+
+// preserveResponseBody reads the response body and creates a new reader for it.
+// This is necessary because the response body can only be read once.
+func preserveResponseBody(resp *http.Response) error {
+	if resp == nil || resp.Body == nil {
+		return nil
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	if err != nil {
+		return fmt.Errorf("failed to read response body in round tripper: %w", err)
+	}
+	resp.Body = io.NopCloser(bytes.NewReader(body))
+	return nil
 }

--- a/internal/bitwarden/webapi/retry_round_tripper_test.go
+++ b/internal/bitwarden/webapi/retry_round_tripper_test.go
@@ -1,0 +1,272 @@
+//go:build offline
+
+package webapi
+
+import (
+	"context"
+	"errors"
+	"math"
+	"net"
+	"net/http"
+	"os"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBackoff(t *testing.T) {
+	testData := map[int]time.Duration{
+		1: 2 * time.Second,
+		2: 4 * time.Second,
+		3: 8 * time.Second,
+		4: 16 * time.Second,
+		5: 30 * time.Second,
+		6: 30 * time.Second,
+	}
+	for attempt, expected := range testData {
+		assert.Equal(t, expected, backoff(attempt))
+	}
+}
+
+func TestRetryRoundTripper_BasicRetry(t *testing.T) {
+	lowerBackoffFactor()
+	defer lowerBackoffFactor()
+
+	// Create a transport that fails once then succeeds
+	transport := &mockTransport{
+		responses: []*http.Response{
+			nil,
+			{StatusCode: http.StatusOK},
+		},
+		errors: []error{
+			&net.OpError{Op: "dial", Err: errors.New("connection refused")},
+			nil,
+		},
+	}
+
+	rrt := NewRetryRoundTripper(1, 3, time.Second)
+	rrt.Transport = transport
+
+	req, err := http.NewRequest("GET", "http://example.com", nil)
+	require.NoError(t, err)
+
+	resp, err := rrt.RoundTrip(req)
+	require.NoError(t, err)
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, 2, transport.index)
+}
+
+func TestRetryRoundTripper_ServiceUnavailable(t *testing.T) {
+	lowerBackoffFactor()
+	defer lowerBackoffFactor()
+
+	// Create a transport that returns 503 then succeeds
+	transport := &mockTransport{
+		responses: []*http.Response{
+			{StatusCode: http.StatusServiceUnavailable},
+			{StatusCode: http.StatusOK},
+		},
+		errors: []error{nil, nil},
+	}
+
+	rrt := NewRetryRoundTripper(1, 3, time.Second)
+	rrt.Transport = transport
+
+	req, err := http.NewRequest("GET", "http://example.com", nil)
+	require.NoError(t, err)
+
+	resp, err := rrt.RoundTrip(req)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, 2, transport.index)
+}
+
+func TestRetryRoundTripper_ConcurrentRequests(t *testing.T) {
+	transport := &mockTransport{
+		responses: []*http.Response{
+			{StatusCode: http.StatusOK},
+			{StatusCode: http.StatusOK},
+			{StatusCode: http.StatusOK},
+		},
+		errors: []error{nil, nil, nil},
+	}
+
+	rrt := NewRetryRoundTripper(2, 3, time.Second)
+	rrt.Transport = transport
+
+	// Create a channel to coordinate the requests
+	start := make(chan struct{})
+	done := make(chan struct{})
+
+	// Launch 3 concurrent requests
+	for i := 0; i < 3; i++ {
+		go func() {
+			<-start
+			req, _ := http.NewRequest("GET", "http://example.com", nil)
+			rrt.RoundTrip(req)
+			done <- struct{}{}
+		}()
+	}
+
+	// Start all requests at once
+	close(start)
+
+	// Wait for all requests to complete
+	for i := 0; i < 3; i++ {
+		<-done
+	}
+
+	// Verify that all requests were processed
+	assert.Equal(t, 3, transport.index)
+}
+
+func TestRetryRoundTripper_RequestTimeout(t *testing.T) {
+	lowerBackoffFactor()
+	defer lowerBackoffFactor()
+
+	transport := &mockTransport{
+		responses: []*http.Response{nil},
+		errors:    []error{context.DeadlineExceeded},
+	}
+
+	rrt := NewRetryRoundTripper(1, 3, 100*time.Millisecond)
+	rrt.Transport = transport
+
+	req, err := http.NewRequest("GET", "http://example.com", nil)
+	require.NoError(t, err)
+
+	// Create a context with a shorter timeout
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+	req = req.WithContext(ctx)
+
+	resp, err := rrt.RoundTrip(req)
+	assert.Error(t, err)
+	assert.Nil(t, resp)
+	assert.Contains(t, err.Error(), "context deadline exceeded")
+}
+
+func TestRetryRoundTripper_DisableRetries(t *testing.T) {
+	lowerBackoffFactor()
+	defer lowerBackoffFactor()
+
+	transport := &mockTransport{
+		responses: []*http.Response{
+			{StatusCode: http.StatusServiceUnavailable},
+		},
+		errors: []error{nil},
+	}
+
+	rrt := NewRetryRoundTripper(1, 3, time.Second)
+	rrt.Transport = transport
+	rrt.DisableRetries = true
+
+	req, err := http.NewRequest("GET", "http://example.com", nil)
+	require.NoError(t, err)
+
+	resp, err := rrt.RoundTrip(req)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusServiceUnavailable, resp.StatusCode)
+	assert.Equal(t, 1, transport.index)
+}
+
+func TestRetryRoundTripper_NonGetRequest(t *testing.T) {
+	lowerBackoffFactor()
+	defer lowerBackoffFactor()
+
+	transport := &mockTransport{
+		responses: []*http.Response{nil},
+		errors:    []error{&net.OpError{Op: "dial", Err: errors.New("connection refused")}},
+	}
+
+	rrt := NewRetryRoundTripper(1, 3, time.Second)
+	rrt.Transport = transport
+
+	req, err := http.NewRequest("POST", "http://example.com", nil)
+	require.NoError(t, err)
+
+	resp, err := rrt.RoundTrip(req)
+	assert.Error(t, err)
+	assert.Nil(t, resp)
+	assert.Equal(t, 1, transport.index)
+}
+
+func TestIsConnectTimeout(t *testing.T) {
+	lowerBackoffFactor()
+	defer lowerBackoffFactor()
+
+	// Test with a temporary error
+	tempErr := &net.OpError{
+		Op:  "dial",
+		Err: &os.SyscallError{Syscall: "connect", Err: syscall.EAGAIN},
+	}
+	assert.True(t, isDialError(tempErr))
+
+	// Test with a non-temporary error
+	nonTempErr := &net.OpError{
+		Op:  "dial",
+		Err: &os.SyscallError{Syscall: "connect", Err: syscall.ECONNREFUSED},
+	}
+	assert.True(t, isDialError(nonTempErr))
+
+	// Test with a non-dial error
+	readErr := &net.OpError{
+		Op:  "read",
+		Err: &os.SyscallError{Syscall: "read", Err: syscall.EAGAIN},
+	}
+	assert.False(t, isDialError(readErr))
+
+	// Test with nil
+	assert.False(t, isDialError(nil))
+}
+
+func TestRetryRoundTripper_ReadWaitDurationFromHeaders(t *testing.T) {
+
+	testData := []struct {
+		header   http.Header
+		duration time.Duration
+	}{
+		{
+			header:   http.Header{"X-Retry-After": []string{"1"}},
+			duration: 1 * time.Minute,
+		},
+		{
+			header:   http.Header{"X-Rate-Limit-Reset": []string{time.Now().Add(15 * time.Second).UTC().Format(time.RFC3339)}, "X-Retry-After": []string{"1"}},
+			duration: 15 * time.Second,
+		},
+	}
+
+	for _, test := range testData {
+		duration := tryToReadWaitDurationFromHeaders(&http.Response{StatusCode: http.StatusTooManyRequests, Header: test.header})
+		assert.True(t, math.Abs(float64(duration-test.duration)) <= float64(time.Second),
+			"Duration %v should be within 1 second of expected %v", duration, test.duration)
+	}
+}
+
+type mockTransport struct {
+	responses []*http.Response
+	errors    []error
+	index     int
+}
+
+func (m *mockTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	if m.index >= len(m.responses) {
+		return nil, errors.New("no more responses")
+	}
+	resp := m.responses[m.index]
+	err := m.errors[m.index]
+	m.index++
+	return resp, err
+}
+
+func lowerBackoffFactor() func() {
+	originalBackoffFactor := retryBackoffFactor
+	retryBackoffFactor = 0
+	return func() {
+		retryBackoffFactor = originalBackoffFactor
+	}
+}

--- a/internal/bitwarden/webapi/retry_round_tripper_test.go
+++ b/internal/bitwarden/webapi/retry_round_tripper_test.go
@@ -9,6 +9,7 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"sync"
 	"syscall"
 	"testing"
 	"time"
@@ -251,9 +252,13 @@ type mockTransport struct {
 	responses []*http.Response
 	errors    []error
 	index     int
+	mu        sync.Mutex
 }
 
 func (m *mockTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
 	if m.index >= len(m.responses) {
 		return nil, errors.New("no more responses")
 	}


### PR DESCRIPTION
* add support for retrying on HTTP status codes other than 503 (the EU Bitwarden instances seem a bit less stable than the US)
* apply requestTimeout only to individual requests, and not the overall requests+retries
* support the `X-Rate-Limit-Reset` hint
* add tests