### PR TITLE
check presence of secrets to skip (or not) tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -113,7 +113,7 @@ jobs:
 
     # Only runs after the Secrets Manager to prevent rate limiting on login.
     needs: [secrets_manager_bitwarden]
-    if: github.event_name == 'workflow_dispatch' || github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
+    if: secrets.BITWARDEN_EMAIL != ''
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/setup-test
@@ -141,7 +141,7 @@ jobs:
 
   secrets_manager_bitwarden:
     runs-on: ubuntu-latest
-    if: github.event_name == 'workflow_dispatch' || github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
+    if: secrets.BITWARDEN_EMAIL != ''
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/setup-test


### PR DESCRIPTION
Check the presence of Github Secrets to decide if integration tests should run or not. This should fix the Dependabot PRs.