### PR TITLE
chore(docs): clarify machine account permissions

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -120,6 +120,11 @@ In order to generate an Access Token you need to:
 6. Select the _Access Tokens_ tab
 7. Created a new Access Token and save it somewhere safe
 
+> [!TIP]
+> By default, new machine accounts are not assigned to any projects.
+> After creating a machine account, make sure it is added to the project(s) you want to access, with either "Can Read" or "Can Read & Write" permissions.
+> If the machine account does not have access to the project,
+> you will encounter an `Error: object not found` when attempting to use/create secrets from that project.
 
 ## Configuration
 Configuration for the Bitwarden Provider can be derived from two sources:


### PR DESCRIPTION
Good day @maxlaverse ,

this is a very small edition, that confused me a lot last evening, when I was trying to use the bitwarden secrets.


Essentially the plugin would crash with a mystic exception

<img width="1632" height="362" alt="image" src="https://github.com/user-attachments/assets/79d9e094-6f8d-4b87-ab9f-0cd10913981d" />

Probably there is a better way to fix this, but for now I just added a clarification note, so other people do not get confused.