### PR TITLE
introduce client_implementation attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,15 +56,13 @@ provider "bitwarden" {
   access_token = "0.client_id.client_secret:dGVzdC1lbmNyeXB0aW9uLWtleQ=="
 
   # By default, the provider uses Bitwarden CLIs to interact with the remote
-  # Vaults. You can also decide to a client embedded in the provider instead,
-  # which removes the need for locally installed binaries.
+  # Vaults. You can also use the embedded client instead, which removes
+  # the need for locally installed binaries.
   #
   # Learn more about the implications by reading the "Client Implementation"
   # section below.
   #
-  # experimental {
-  #   embedded_client = true
-  # }
+  # client_implementation = "embedded"
 }
 
 # Source a project
@@ -105,15 +103,13 @@ provider "bitwarden" {
   # server = "https://vault.bitwarden.eu"
 
   # By default, the provider uses Bitwarden CLIs to interact with the remote
-  # Vaults. You can also decide to a client embedded in the provider instead,
-  # which removes the need for locally installed binaries.
+  # Vaults. You can also use the embedded client instead, which removes
+  # the need for locally installed binaries.
   #
   # Learn more about the implications by reading the "Client Implementation"
   # section below.
   #
-  # experimental {
-  #   embedded_client = true
-  # }
+  # client_implementation = "embedded"
 }
 
 # Create a Bitwarden Login item

--- a/docs/index.md
+++ b/docs/index.md
@@ -27,15 +27,13 @@ provider "bitwarden" {
   email = "terraform@example.com"
 
   # By default, the provider uses Bitwarden CLIs to interact with the remote
-  # Vaults. You can also decide to a client embedded in the provider instead,
-  # which removes the need for locally installed binaries.
+  # Vaults. You can also use the embedded client instead, which removes
+  # the need for locally installed binaries.
   #
   # Learn more about the implications by reading the "Client Implementation"
   # section below.
   #
-  # experimental {
-  #   embedded_client = true
-  # }
+  # client_implementation = "embedded"
 }
 
 # Create a Bitwarden Login item
@@ -142,13 +140,9 @@ provider "bitwarden" {
   # server = "https://vault.bitwarden.eu"
 
   # If you have the opportunity, you can try out the embedded client which
-  # removes the need for a locally installed Bitwarden CLI. Please note that
-  # this feature is still considered experimental and not recommended for
-  # production use yet.
+  # removes the need for a locally installed Bitwarden CLI.
   #
-  # experimental {
-  #   embedded_client = true
-  # }
+  # client_implementation = "embedded"
 }
 ```
 
@@ -174,6 +168,7 @@ export BW_CLIENTSECRET="my-client-secret"
 
 - `access_token` (String) Machine Account Access Token (env: `BWS_ACCESS_TOKEN`)).
 - `client_id` (String) Client ID (env: `BW_CLIENTID`)
+- `client_implementation` (String) Client implementation type. Valid values are "embedded" (use embedded client) or "cli" (use CLI binaries, default).
 - `client_secret` (String) Client Secret (env: `BW_CLIENTSECRET`). Do not commit this information in Git unless you know what you're doing. Prefer using a Terraform `variable {}` in order to inject this value from the environment.
 - `email` (String) Login Email of the Vault (env: `BW_EMAIL`).
 - `experimental` (Block Set) Enable experimental features. (see [below for nested schema](#nestedblock--experimental))
@@ -189,7 +184,7 @@ export BW_CLIENTSECRET="my-client-secret"
 Optional:
 
 - `disable_sync_after_write_verification` (Boolean) Skip verification of server-side modifications (like timestamp updates) after write operations - useful when the Bitwarden server makes minor, non-functional changes to objects.
-- `embedded_client` (Boolean) Use the embedded client instead of an external binary.
+- `embedded_client` (Boolean, Deprecated) Use the embedded client instead of an external binary.
 
 [Password Manager]: https://bitwarden.com/products/personal/
 [Secrets Manager]: https://bitwarden.com/products/secrets-manager/

--- a/examples/quick/provider.tf
+++ b/examples/quick/provider.tf
@@ -12,15 +12,13 @@ provider "bitwarden" {
   email = "terraform@example.com"
 
   # By default, the provider uses Bitwarden CLIs to interact with the remote
-  # Vaults. You can also decide to a client embedded in the provider instead,
-  # which removes the need for locally installed binaries.
+  # Vaults. You can also use the embedded client instead, which removes
+  # the need for locally installed binaries.
   #
   # Learn more about the implications by reading the "Client Implementation"
   # section below.
   #
-  # experimental {
-  #   embedded_client = true
-  # }
+  # client_implementation = "embedded"
 }
 
 # Create a Bitwarden Login item

--- a/internal/bitwarden/embedded/org_cache.go
+++ b/internal/bitwarden/embedded/org_cache.go
@@ -18,10 +18,10 @@ type OrgCache struct {
 }
 
 type orgCacheEntry struct {
-	groups  []models.OrgGroup
-	members []models.OrgMember
-    groupsLoaded  bool
-    membersLoaded bool	
+	groups        []models.OrgGroup
+	members       []models.OrgMember
+	groupsLoaded  bool
+	membersLoaded bool
 }
 
 func NewOrgCache(client webapi.Client) OrgCache {
@@ -33,28 +33,28 @@ func NewOrgCache(client webapi.Client) OrgCache {
 
 // GetGroups returns cached groups for an organization, loading them if needed
 func (c *OrgCache) GetGroups(ctx context.Context, orgId string) ([]models.OrgGroup, error) {
-    c.mu.RLock()
-    entry, exists := c.cache[orgId]
-    if exists && entry.groupsLoaded {
-        groups := entry.groups
-        c.mu.RUnlock()
-        return groups, nil
-    }
-    c.mu.RUnlock()
-    return c.loadGroups(ctx, orgId)
+	c.mu.RLock()
+	entry, exists := c.cache[orgId]
+	if exists && entry.groupsLoaded {
+		groups := entry.groups
+		c.mu.RUnlock()
+		return groups, nil
+	}
+	c.mu.RUnlock()
+	return c.loadGroups(ctx, orgId)
 }
 
 // GetMembers returns cached members for an organization, loading them if needed
 func (c *OrgCache) GetMembers(ctx context.Context, orgId string) ([]models.OrgMember, error) {
-    c.mu.RLock()
-    entry, exists := c.cache[orgId]
-    if exists && entry.membersLoaded {
-        members := entry.members
-        c.mu.RUnlock()
-        return members, nil
-    }
-    c.mu.RUnlock()
-    return c.loadMembers(ctx, orgId)
+	c.mu.RLock()
+	entry, exists := c.cache[orgId]
+	if exists && entry.membersLoaded {
+		members := entry.members
+		c.mu.RUnlock()
+		return members, nil
+	}
+	c.mu.RUnlock()
+	return c.loadMembers(ctx, orgId)
 }
 
 // FindGroupByID finds a group by ID in the specified organization
@@ -157,32 +157,32 @@ func (c *OrgCache) InvalidateAll(ctx context.Context) {
 
 // loadGroups loads groups from the API and caches them
 func (c *OrgCache) loadGroups(ctx context.Context, orgId string) ([]models.OrgGroup, error) {
-    c.mu.Lock()
-    defer c.mu.Unlock()
+	c.mu.Lock()
+	defer c.mu.Unlock()
 
-    tflog.Trace(ctx, "Loading groups for organization", map[string]interface{}{"org_id": orgId})
+	tflog.Trace(ctx, "Loading groups for organization", map[string]interface{}{"org_id": orgId})
 
-    orgGroups, err := c.client.GetOrganizationGroups(ctx, orgId)
-    if err != nil {
-        return nil, fmt.Errorf("error getting organization groups: %w", err)
-    }
+	orgGroups, err := c.client.GetOrganizationGroups(ctx, orgId)
+	if err != nil {
+		return nil, fmt.Errorf("error getting organization groups: %w", err)
+	}
 
-    groups := make([]models.OrgGroup, len(orgGroups))
-    for i, g := range orgGroups {
-        groups[i] = models.OrgGroup{ ID: g.Id, Name: g.Name, OrganizationID: orgId }
-    }
+	groups := make([]models.OrgGroup, len(orgGroups))
+	for i, g := range orgGroups {
+		groups[i] = models.OrgGroup{ID: g.Id, Name: g.Name, OrganizationID: orgId}
+	}
 
-    if entry, ok := c.cache[orgId]; ok {
-        entry.groups = groups
-        entry.groupsLoaded = true
-        // keep entry.members / entry.membersLoaded as-is
-    } else {
-        c.cache[orgId] = &orgCacheEntry{
-            groups:       groups,
-            groupsLoaded: true,
-        }
-    }
-    return groups, nil
+	if entry, ok := c.cache[orgId]; ok {
+		entry.groups = groups
+		entry.groupsLoaded = true
+		// keep entry.members / entry.membersLoaded as-is
+	} else {
+		c.cache[orgId] = &orgCacheEntry{
+			groups:       groups,
+			groupsLoaded: true,
+		}
+	}
+	return groups, nil
 }
 
 // loadMembers loads members from the API and caches them
@@ -208,16 +208,16 @@ func (c *OrgCache) loadMembers(ctx context.Context, orgId string) ([]models.OrgM
 		}
 	}
 
-    if entry, ok := c.cache[orgId]; ok {
-        entry.members = members
-        entry.membersLoaded = true
-        // keep entry.groups / entry.groupsLoaded as-is
-    } else {
-        c.cache[orgId] = &orgCacheEntry{
-            members:       members,
-            membersLoaded: true,
-        }
-    }
+	if entry, ok := c.cache[orgId]; ok {
+		entry.members = members
+		entry.membersLoaded = true
+		// keep entry.groups / entry.groupsLoaded as-is
+	} else {
+		c.cache[orgId] = &orgCacheEntry{
+			members:       members,
+			membersLoaded: true,
+		}
+	}
 
 	return members, nil
 }

--- a/internal/provider/provider_basic_auth_test.go
+++ b/internal/provider/provider_basic_auth_test.go
@@ -96,12 +96,9 @@ func usernamePasswordTestProvider(email, password string) string {
 		master_password = "%s"
 		server          = "%s"
 		email           = "%s"
-
-		experimental {
-			embedded_client = %s
-		}
+		client_implementation = "%s"
 	}
-`, password, testConfiguration.ServerURL, email, testConfiguration.UseEmbeddedClientStr())
+`, password, testConfiguration.ServerURL, email, testConfiguration.ClientImplementationStr())
 }
 
 func checkResourceId() resource.TestCheckFunc {

--- a/internal/provider/provider_utils_test.go
+++ b/internal/provider/provider_utils_test.go
@@ -99,12 +99,9 @@ func tfConfigPasswordManagerProvider(account testAccountName) string {
 		email           = "%s"
 		client_id       = "%s"
 		client_secret   = "%s"
-
-		experimental {
-			embedded_client = %s
-		}
+		client_implementation = "%s"
 	}
-`, acc.Password, testConfiguration.ServerURL, acc.Email, acc.ClientID, acc.ClientSecret, testConfiguration.UseEmbeddedClientStr())
+`, acc.Password, testConfiguration.ServerURL, acc.Email, acc.ClientID, acc.ClientSecret, testConfiguration.ClientImplementationStr())
 }
 
 func tfConfigAttachmentSpecificPasswordManagerProvider() string {
@@ -118,12 +115,9 @@ func tfConfigAttachmentSpecificPasswordManagerProvider() string {
 		master_password = "%s"
 		server          = "%s"
 		email           = "%s"
-
-		experimental {
-			embedded_client = false
-		}
+		client_implementation = "%s"
 	}
-`, acc.Password, testConfiguration.ReverseProxyServerURL, acc.Email)
+`, acc.Password, testConfiguration.ReverseProxyServerURL, acc.Email, testConfiguration.ClientImplementationStr())
 }
 
 func testOrRealSecretsManagerProvider(t *testing.T) (string, func()) {
@@ -155,12 +149,9 @@ func spawnTestSecretsManager(t *testing.T) (string, func()) {
 	provider "bitwarden" {
 		access_token = "%s"
 		server = "http://localhost:8081"
-
-		experimental {
-			embedded_client = %s
-		}
+		client_implementation = "%s"
 	}
-	`, accessToken, testConfiguration.UseEmbeddedClientStr()), stop
+	`, accessToken, testConfiguration.ClientImplementationStr()), stop
 }
 
 func tfConfigSecretsManagerProvider() string {
@@ -168,11 +159,9 @@ func tfConfigSecretsManagerProvider() string {
 	provider "bitwarden" {
 		access_token = "%s"
 		server = "%s"
-		experimental {
-			embedded_client = %s
-		}
+		client_implementation = "%s"
 	}
-`, os.Getenv("TEST_SECRETS_MANAGER_ACCESS_TOKEN"), testConfiguration.ServerURL, testConfiguration.UseEmbeddedClientStr())
+`, os.Getenv("TEST_SECRETS_MANAGER_ACCESS_TOKEN"), testConfiguration.ServerURL, testConfiguration.ClientImplementationStr())
 }
 
 func getObjectID(n string, objectId *string) resource.TestCheckFunc {

--- a/internal/provider/testhelper_config_test.go
+++ b/internal/provider/testhelper_config_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/joho/godotenv"
 	"github.com/maxlaverse/terraform-provider-bitwarden/internal/bitwarden/models"
+	"github.com/maxlaverse/terraform-provider-bitwarden/internal/schema_definition"
 )
 
 const (
@@ -76,6 +77,13 @@ func (c *testConfigStruct) UseEmbeddedClientStr() string {
 		return "true"
 	}
 	return "false"
+}
+
+func (c *testConfigStruct) ClientImplementationStr() string {
+	if c.UseEmbeddedClient {
+		return schema_definition.ClientImplementationEmbedded
+	}
+	return schema_definition.ClientImplementationCLI
 }
 
 func (c *testConfigStruct) WasResourcesCreationAttempted(t *testing.T) bool {

--- a/internal/schema_definition/schema_attributes.go
+++ b/internal/schema_definition/schema_attributes.go
@@ -113,6 +113,7 @@ const (
 	// Provider field attributes
 	AttributeBwsAccessToken                                = "access_token"
 	AttributeClientID                                      = "client_id"
+	AttributeClientImplementation                          = "client_implementation"
 	AttributeClientSecret                                  = "client_secret"
 	AttributeProviderEmail                                 = "email"
 	AttributeMasterPassword                                = "master_password"
@@ -124,6 +125,10 @@ const (
 	AttributeExperimentalEmbeddedClient                    = "embedded_client"
 	AttributeExperimentalDisableSyncAfterWriteVerification = "disable_sync_after_write_verification"
 
+	// Client implementation values
+	ClientImplementationCLI      = "cli"
+	ClientImplementationEmbedded = "embedded"
+
 	// Provider field descriptions
 	DescriptionBwsAccessToken                                = "Machine Account Access Token (env: `BWS_ACCESS_TOKEN`))."
 	DescriptionClientSecret                                  = "Client Secret (env: `BW_CLIENTSECRET`). Do not commit this information in Git unless you know what you're doing. Prefer using a Terraform `variable {}` in order to inject this value from the environment."
@@ -134,6 +139,7 @@ const (
 	DescriptionSessionKey                                    = "A Bitwarden Session Key (env: `BW_SESSION`)"
 	DescriptionVaultPath                                     = "Alternative directory for storing the Vault locally (default: `.bitwarden/`, env: `BITWARDENCLI_APPDATA_DIR`; set to empty string to use CLI default)."
 	DescriptionExtraCACertsPath                              = "Extends the well known 'root' CAs (like VeriSign) with the extra certificates in file (env: `NODE_EXTRA_CA_CERTS`, doesn't work with embedded client)."
+	DescriptionClientImplementation                          = "Client implementation type. Valid values are \"embedded\" (use embedded client) or \"cli\" (use CLI binaries, default)."
 	DescriptionExperimental                                  = "Enable experimental features."
 	DescriptionExperimentalEmbeddedClient                    = "Use the embedded client instead of an external binary."
 	DescriptionExperimentalDisableSyncAfterWriteVerification = "Skip verification of server-side modifications (like timestamp updates) after write operations - useful when the Bitwarden server makes minor, non-functional changes to objects."

--- a/templates/index.md.tmpl
+++ b/templates/index.md.tmpl
@@ -105,13 +105,9 @@ provider "bitwarden" {
   # server = "https://vault.bitwarden.eu"
 
   # If you have the opportunity, you can try out the embedded client which
-  # removes the need for a locally installed Bitwarden CLI. Please note that
-  # this feature is still considered experimental and not recommended for
-  # production use yet.
+  # removes the need for a locally installed Bitwarden CLI.
   #
-  # experimental {
-  #   embedded_client = true
-  # }
+  # client_implementation = "embedded"
 }
 ```
 


### PR DESCRIPTION
introduce a new `client_implementation` attribute to replace the experimental `use_embedded_client`