### PR TITLE
fix backward compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ terraform {
   required_providers {
     bitwarden = {
       source  = "maxlaverse/bitwarden"
-      version = ">= 0.16.0"
+      version = ">= 0.17.1"
     }
   }
 }
@@ -88,7 +88,7 @@ terraform {
   required_providers {
     bitwarden = {
       source  = "maxlaverse/bitwarden"
-      version = ">= 0.16.0"
+      version = ">= 0.17.1"
     }
   }
 }

--- a/docs/index.md
+++ b/docs/index.md
@@ -17,7 +17,7 @@ terraform {
   required_providers {
     bitwarden = {
       source  = "maxlaverse/bitwarden"
-      version = ">= 0.16.0"
+      version = ">= 0.17.1"
     }
   }
 }

--- a/examples/quick/provider.tf
+++ b/examples/quick/provider.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     bitwarden = {
       source  = "maxlaverse/bitwarden"
-      version = ">= 0.16.0"
+      version = ">= 0.17.1"
     }
   }
 }

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -121,11 +121,14 @@ func New(version string) func() *schema.Provider {
 					Elem: &schema.Resource{
 						Schema: map[string]*schema.Schema{
 							schema_definition.AttributeExperimentalEmbeddedClient: {
-								Description:   schema_definition.DescriptionExperimentalEmbeddedClient,
-								Type:          schema.TypeBool,
-								Optional:      true,
-								Deprecated:    "Use client_implementation = \"embedded\" instead.",
-								ConflictsWith: []string{schema_definition.AttributeClientImplementation},
+								Description: schema_definition.DescriptionExperimentalEmbeddedClient,
+								Type:        schema.TypeBool,
+								Optional:    true,
+								Deprecated:  "Use client_implementation = \"embedded\" instead.",
+								// Note: We don't use ConflictsWith because client_implementation has a default value. To
+								// properly detect if it was explicitly set (vs using the default) would require additional
+								// code. Instead, we allow both to be set and let experimental.embedded_client take
+								// precedence in getClientImplementation().
 							},
 							schema_definition.AttributeExperimentalDisableSyncAfterWriteVerification: {
 								Description: schema_definition.DescriptionExperimentalDisableSyncAfterWriteVerification,
@@ -170,7 +173,6 @@ func providerConfigure(version string, _ *schema.Provider) func(context.Context,
 	shouldLogin := !strings.Contains(version, versionTestSkippedLogin)
 
 	return func(ctx context.Context, d *schema.ResourceData) (interface{}, diag.Diagnostics) {
-
 		_, hasAccessToken := d.GetOk(schema_definition.AttributeBwsAccessToken)
 		useEmbeddedClient := getClientImplementation(d) == schema_definition.ClientImplementationEmbedded
 


### PR DESCRIPTION
Fixes https://github.com/maxlaverse/terraform-provider-bitwarden/issues/337

Using `ConflictsWith` with an attribute that has a default value is causing trouble, because `client_implementation` is seen has set to the default value, which causes conflict whenever `experimental.embedded_client` is set.

The easiest for now is just to remove this mutual exclusion. Having both set is an edge case anyway.
