### PR TITLE
improve timeouts & retries

### DIFF
--- a/internal/bitwarden/webapi/client.go
+++ b/internal/bitwarden/webapi/client.go
@@ -21,9 +21,12 @@ import (
 )
 
 const (
-	defaultRequestTimeout = 10 * time.Second
-	maxConcurrentRequests = 4
-	maxRetryAttempts      = 3
+	defaultDialTimeout           = 10 * time.Second
+	defaultTLSHandshakeTimeout   = 10 * time.Second
+	defaultResponseHeaderTimeout = 10 * time.Second
+	defaultAttemptTimeout        = 15 * time.Second
+	maxConcurrentRequests        = 4
+	maxRetryAttempts             = 3
 )
 
 type CloudStorageProvider string
@@ -86,7 +89,7 @@ func NewClient(serverURL, deviceIdentifier, providerVersion string, opts ...Opti
 		device:    DeviceInformation(deviceIdentifier, providerVersion),
 		serverURL: strings.TrimSuffix(serverURL, "/"),
 		httpClient: &http.Client{
-			Transport:     NewRetryRoundTripper(maxConcurrentRequests, maxRetryAttempts, defaultRequestTimeout),
+			Transport:     NewRetryRoundTripper(maxConcurrentRequests, maxRetryAttempts, defaultAttemptTimeout, defaultDialTimeout, defaultTLSHandshakeTimeout, defaultResponseHeaderTimeout),
 			CheckRedirect: handleRedirect,
 		},
 	}

--- a/internal/bitwarden/webapi/retry_round_tripper.go
+++ b/internal/bitwarden/webapi/retry_round_tripper.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"slices"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-log/tflog"
@@ -23,7 +24,7 @@ type RetryRoundTripper struct {
 
 	concurrentRequestsSem *semaphore.Weighted
 	maxRetries            int
-	requestTimeout        time.Duration
+	attemptTimeout        time.Duration
 }
 
 // List of status codes that are considered retryable depending on the method.
@@ -40,13 +41,17 @@ var retryBackoffFactor = 1.5
 //   - maxConcurrentRequests: Maximum number of concurrent requests allowed
 //   - maxRetries: Maximum number of retries for low-level errors (e.g. timeouts) and
 //     bad status codes (e.g. 503). A value of 0 means no retries.
-//   - requestTimeout: Timeout duration that applies to individual request attempts
-func NewRetryRoundTripper(maxConcurrentRequests int, maxRetries int, requestTimeout time.Duration) *RetryRoundTripper {
+//   - attemptTimeout: Timeout duration that applies to the per-attempt context
+//     (overall bound for a single attempt, includes everything).
+//   - dialTimeout: Timeout for DNS + TCP connect. 0 means no timeout (infinite).
+//   - tlsHandshakeTimeout: Timeout for TLS handshake. 0 means no timeout (infinite).
+//   - responseHeaderTimeout: Timeout for reading response headers. 0 means no timeout (infinite).
+func NewRetryRoundTripper(maxConcurrentRequests int, maxRetries int, attemptTimeout, dialTimeout, tlsHandshakeTimeout, responseHeaderTimeout time.Duration) *RetryRoundTripper {
 	return &RetryRoundTripper{
-		Transport:             http.DefaultTransport,
+		Transport:             newBaseTransport(dialTimeout, tlsHandshakeTimeout, responseHeaderTimeout),
 		concurrentRequestsSem: semaphore.NewWeighted(int64(maxConcurrentRequests)),
 		maxRetries:            maxRetries,
-		requestTimeout:        requestTimeout,
+		attemptTimeout:        attemptTimeout,
 	}
 }
 
@@ -92,40 +97,38 @@ func (rrt *RetryRoundTripper) RoundTrip(httpReq *http.Request) (*http.Response, 
 }
 
 func (rrt *RetryRoundTripper) doRequest(originalCtx context.Context, httpReq *http.Request, attemptNumber int) (*http.Response, bool, error) {
-	reqCtx, cancel := context.WithTimeout(originalCtx, rrt.requestTimeout)
+	reqCtx, cancel := context.WithTimeout(originalCtx, rrt.attemptTimeout)
 	defer cancel()
 
 	resp, err := rrt.Transport.RoundTrip(httpReq.WithContext(reqCtx))
 
-	// A request is successful if there's no error and the status code is not retryable
+	// A request is successful if there's no error, we got a response, and the status code is not retryable
 	isSuccessful := err == nil && resp != nil && !isRetriableStatusCode(httpReq.Method, resp.StatusCode)
 
-	// If the request was successful, we return without additional logging.
-	// We preserve the response body as exiting the method cancels the context.
+	// Success: return response, no retry.
 	if isSuccessful {
 		return resp, false, preserveResponseBody(resp)
 	}
 
 	// At this point, there was a problem. We need to check if it's retryable,
 	// and we want to log information in any case.
-	isDialError := err != nil && isDialError(err)
-	isRetriableHttpStatusCode := err == nil && resp != nil && isRetriableStatusCode(httpReq.Method, resp.StatusCode)
-	isRetriableReadTimeout := httpReq.Method == http.MethodGet && (isReadTimeout(err))
 	is429 := resp != nil && resp.StatusCode == http.StatusTooManyRequests
 	// 429 is retried indefinitely (rate limits eventually reset). Other retryable cases use maxRetries.
 	isLastPossibleAttempt := (attemptNumber >= rrt.maxRetries-1 || rrt.DisableRetries) && !is429
+	reasons := retriableReasons(err, httpReq, resp)
+	isRetriable := len(reasons) > 0
+	giveUp := isLastPossibleAttempt || !isRetriable
 
 	debugInfo := map[string]interface{}{
-		"url":                           httpReq.URL.RequestURI(),
-		"method":                        httpReq.Method,
-		"attempt_number":                attemptNumber,
-		"is_last_attempt":               isLastPossibleAttempt,
-		"is_retriable_http_status_code": isRetriableHttpStatusCode,
-		"is_retriable_read_timeout":     isRetriableReadTimeout,
+		"url":               httpReq.URL.RequestURI(),
+		"method":            httpReq.Method,
+		"attempt_number":    attemptNumber,
+		"is_last_attempt":   isLastPossibleAttempt,
+		"retriable_reasons": reasons,
 	}
 
-	// If the request is not retryable, we preserve the response body, log and return.
-	if isLastPossibleAttempt || (!isDialError && !isRetriableHttpStatusCode && !isRetriableReadTimeout) {
+	// Give up: not retriable or last attempt; log and return.
+	if giveUp {
 		tflog.Info(originalCtx, "retry_round_tripper", debugInfo)
 		readErr := preserveResponseBody(resp)
 		if readErr != nil && err != nil {
@@ -136,13 +139,11 @@ func (rrt *RetryRoundTripper) doRequest(originalCtx context.Context, httpReq *ht
 		return resp, false, err
 	}
 
-	// We're going to retry the request, and therefore should throw away the
-	// response body of the previous attempt if it exists.
+	// Retry: discard response body, enrich debugInfo for retry log, then sleep before next attempt.
 	if resp != nil && resp.Body != nil {
 		io.Copy(io.Discard, resp.Body)
 		resp.Body.Close()
 	}
-
 	if err != nil {
 		debugInfo["error"] = err
 	}
@@ -150,15 +151,12 @@ func (rrt *RetryRoundTripper) doRequest(originalCtx context.Context, httpReq *ht
 		debugInfo["status_code"] = resp.StatusCode
 		debugInfo["status_message"] = resp.Status
 	}
-
-	// Default to exponential backoff; use server-provided wait when available for 429.
 	waitDuration := backoff(attemptNumber)
-	if resp != nil && resp.StatusCode == http.StatusTooManyRequests {
+	if is429 {
 		if d := tryToReadWaitDurationFromHeaders(resp); d > 0 {
 			waitDuration = d
 		}
 	}
-
 	debugInfo["wait_duration_sec"] = waitDuration.Seconds()
 	tflog.Info(originalCtx, "retry_round_tripper", debugInfo)
 
@@ -199,6 +197,19 @@ func isDialError(err error) bool {
 	return false
 }
 
+// isTLSHandshakeTimeout reports whether the error is from the transport's
+// TLSHandshakeTimeout being exceeded (transient; retriable). Distinct from
+// other TLS handshake failures (e.g. certificate verification, server alert)
+// which are not retriable.
+func isTLSHandshakeTimeout(err error) bool {
+	for ; err != nil; err = errors.Unwrap(err) {
+		if strings.Contains(err.Error(), "TLS handshake timeout") {
+			return true
+		}
+	}
+	return false
+}
+
 func isReadTimeout(err error) bool {
 	var netErr net.Error
 	if errors.As(err, &netErr) && netErr.Timeout() {
@@ -206,6 +217,28 @@ func isReadTimeout(err error) bool {
 		if ok && opErr.Op == "read" {
 			return true
 		}
+	}
+	return false
+}
+
+// isContextTimeout reports whether the error is due to the request context
+// deadline being exceeded (e.g. our per-attempt request timeout).
+func isContextTimeout(err error) bool {
+	return errors.Is(err, context.DeadlineExceeded)
+}
+
+// isRetriableForResponsePhase reports whether response-phase timeouts (headers,
+// read, or context) should be retried: GET always, or POST when unauthenticated
+// (no Authorization header).
+func isRetriableForResponsePhase(httpReq *http.Request) bool {
+	if httpReq == nil {
+		return false
+	}
+	if httpReq.Method == http.MethodGet {
+		return true
+	}
+	if httpReq.Method == http.MethodPost && httpReq.Header.Get("Authorization") == "" {
+		return true
 	}
 	return false
 }
@@ -260,4 +293,42 @@ func isRetriableStatusCode(method string, statusCode int) bool {
 		return method == http.MethodGet
 	}
 	return false
+}
+
+// retriableReasons returns the reasons why a request is retriable (e.g. dial_error, read_timeout).
+// Empty slice means the request is not retriable.
+func retriableReasons(err error, httpReq *http.Request, resp *http.Response) []string {
+	var reasons []string
+	if err != nil && isDialError(err) {
+		reasons = append(reasons, "dial_error")
+	}
+	if err != nil && isTLSHandshakeTimeout(err) {
+		reasons = append(reasons, "tls_handshake_timeout")
+	}
+	if isRetriableForResponsePhase(httpReq) && isReadTimeout(err) {
+		reasons = append(reasons, "read_timeout")
+	}
+	if resp != nil && isRetriableStatusCode(httpReq.Method, resp.StatusCode) {
+		reasons = append(reasons, "retriable_http_status_code")
+	}
+	if isRetriableForResponsePhase(httpReq) && isContextTimeout(err) {
+		reasons = append(reasons, "context_timeout")
+	}
+	return reasons
+}
+
+// newBaseTransport returns an *http.Transport with the given timeouts.
+// A zero value for any timeout means no timeout (infinite) for that phase.
+func newBaseTransport(dialTimeout, tlsHandshakeTimeout, responseHeaderTimeout time.Duration) *http.Transport {
+	base := http.DefaultTransport.(*http.Transport).Clone()
+	if dialTimeout > 0 {
+		base.DialContext = (&net.Dialer{Timeout: dialTimeout}).DialContext
+	}
+	if tlsHandshakeTimeout > 0 {
+		base.TLSHandshakeTimeout = tlsHandshakeTimeout
+	}
+	if responseHeaderTimeout > 0 {
+		base.ResponseHeaderTimeout = responseHeaderTimeout
+	}
+	return base
 }


### PR DESCRIPTION
Improve timeouts and retries:
* set `DialContext` with a timeout, so we can actually retry those kind of errors
* set `TLSHandshakeTimeout` with a timeout, so we can actually retry those kind of errors
* retry when an attempt took too long overall, if retriable
* make the reason for a retry clearer in the logs

The outcome should be more situations we can retry from.