### PR TITLE
retry on 500s GET

### DIFF
--- a/internal/bitwarden/webapi/retry_round_tripper.go
+++ b/internal/bitwarden/webapi/retry_round_tripper.go
@@ -31,6 +31,7 @@ type RetryRoundTripper struct {
 var retryableStatusCodes = []int{
 	http.StatusTooManyRequests,
 	http.StatusServiceUnavailable,
+	http.StatusInternalServerError,
 }
 
 var retryBackoffFactor = 1.5


### PR DESCRIPTION
Bitwarden's server have been returning 500s when syncing from time to time. This seems like a situation we can safely retry on.