### PR TITLE
remove full-sync after item collection edition

### DIFF
--- a/internal/bitwarden/bwcli/password_manager.go
+++ b/internal/bitwarden/bwcli/password_manager.go
@@ -296,11 +296,6 @@ func (c *client) editItemCollections(ctx context.Context, objId string, collecti
 	if err != nil {
 		return nil, newUnmarshallError(err, args, out)
 	}
-
-	err = c.Sync(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("error syncing: %v, %v", err, string(out))
-	}
 	return &res, nil
 }
 

--- a/internal/provider/resource_item_login_test.go
+++ b/internal/provider/resource_item_login_test.go
@@ -75,6 +75,7 @@ func TestAccResourceItemLoginAddRemoveCollection(t *testing.T) {
 	if err != nil {
 		t.Fatalf("creating login test collection: %v", err)
 	}
+	t.Logf("login test collection: %+v", loginTestCol)
 	loginTestCollectionID := loginTestCol.ID
 	t.Cleanup(func() {
 		if err := bwClient.DeleteOrganizationCollection(context.Background(), models.OrgCollection{


### PR DESCRIPTION
Isn't needed since the cli starts by making an API call before updating the state.