### PR TITLE
Decouple transformations from *schema.ResourceData via AttrData.

### DIFF
--- a/internal/provider/operation_generic.go
+++ b/internal/provider/operation_generic.go
@@ -18,8 +18,8 @@ type deleteOperationFn[T any] func(context.Context, T) error
 type findOperationFn[T any] func(ctx context.Context, options ...bitwarden.ListObjectsOption) (*T, error)
 
 // TransformationOperation
-type schemaToObjectTransformation[T any] func(ctx context.Context, d *schema.ResourceData) T
-type objectToSchemaTransformation[T any] func(ctx context.Context, obj *T, d *schema.ResourceData) error
+type schemaToObjectTransformation[T any] func(ctx context.Context, d transformation.AttrData) T
+type objectToSchemaTransformation[T any] func(ctx context.Context, obj *T, d transformation.AttrData) error
 
 func applyOperation[T any](ctx context.Context, d *schema.ResourceData, clientOperation applyOperationFn[T], fromSchemaToObj schemaToObjectTransformation[T], fromObjToSchema objectToSchemaTransformation[T]) error {
 	obj, err := clientOperation(ctx, fromSchemaToObj(ctx, d))

--- a/internal/transformation/attachment.go
+++ b/internal/transformation/attachment.go
@@ -3,12 +3,11 @@ package transformation
 import (
 	"context"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/maxlaverse/terraform-provider-bitwarden/internal/bitwarden/models"
 	"github.com/maxlaverse/terraform-provider-bitwarden/internal/schema_definition"
 )
 
-func AttachmentObjectToSchema(_ context.Context, attachment models.Attachment, d *schema.ResourceData) error {
+func AttachmentObjectToSchema(_ context.Context, attachment models.Attachment, d AttrData) error {
 	d.SetId(attachment.ID)
 
 	err := d.Set(schema_definition.AttributeAttachmentFileName, attachment.FileName)

--- a/internal/transformation/attrdata.go
+++ b/internal/transformation/attrdata.go
@@ -1,0 +1,33 @@
+package transformation
+
+// AttrData is an SDK-agnostic view of Terraform resource/data-source attributes.
+// It decouples domain mapping from terraform-plugin-sdk's *schema.ResourceData
+// so the same mapping logic can later target Plugin Framework state models.
+//
+// *schema.ResourceData already satisfies this interface.
+type AttrData interface {
+	Id() string
+	SetId(id string)
+	Get(key string) interface{}
+	GetOk(key string) (interface{}, bool)
+	Set(key string, value interface{}) error
+}
+
+// asInterfaceList normalizes SDKv2 *schema.Set values (via List()) and plain
+// slices into []interface{} without importing the SDK.
+func asInterfaceList(v interface{}) ([]interface{}, bool) {
+	switch vv := v.(type) {
+	case []interface{}:
+		return vv, true
+	case []string:
+		out := make([]interface{}, len(vv))
+		for i, s := range vv {
+			out[i] = s
+		}
+		return out, true
+	case interface{ List() []interface{} }:
+		return vv.List(), true
+	default:
+		return nil, false
+	}
+}

--- a/internal/transformation/attrdata_test.go
+++ b/internal/transformation/attrdata_test.go
@@ -1,0 +1,32 @@
+package transformation
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type fakeSet struct {
+	items []interface{}
+}
+
+func (s fakeSet) List() []interface{} { return s.items }
+
+func TestAsInterfaceList(t *testing.T) {
+	t.Parallel()
+
+	list, ok := asInterfaceList([]interface{}{"a", "b"})
+	assert.True(t, ok)
+	assert.Equal(t, []interface{}{"a", "b"}, list)
+
+	list, ok = asInterfaceList([]string{"x", "y"})
+	assert.True(t, ok)
+	assert.Equal(t, []interface{}{"x", "y"}, list)
+
+	list, ok = asInterfaceList(fakeSet{items: []interface{}{"1"}})
+	assert.True(t, ok)
+	assert.Equal(t, []interface{}{"1"}, list)
+
+	_, ok = asInterfaceList(42)
+	assert.False(t, ok)
+}

--- a/internal/transformation/folder.go
+++ b/internal/transformation/folder.go
@@ -3,12 +3,11 @@ package transformation
 import (
 	"context"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/maxlaverse/terraform-provider-bitwarden/internal/bitwarden/models"
 	"github.com/maxlaverse/terraform-provider-bitwarden/internal/schema_definition"
 )
 
-func FolderObjectToSchema(ctx context.Context, obj *models.Folder, d *schema.ResourceData) error {
+func FolderObjectToSchema(ctx context.Context, obj *models.Folder, d AttrData) error {
 	if obj == nil {
 		// Object has been deleted
 		return nil
@@ -24,7 +23,7 @@ func FolderObjectToSchema(ctx context.Context, obj *models.Folder, d *schema.Res
 	return nil
 }
 
-func SchemaToFolderObject(ctx context.Context, d *schema.ResourceData) models.Folder {
+func SchemaToFolderObject(ctx context.Context, d AttrData) models.Folder {
 	var obj models.Folder
 
 	obj.ID = d.Id()

--- a/internal/transformation/item.go
+++ b/internal/transformation/item.go
@@ -3,12 +3,11 @@ package transformation
 import (
 	"context"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/maxlaverse/terraform-provider-bitwarden/internal/bitwarden/models"
 	"github.com/maxlaverse/terraform-provider-bitwarden/internal/schema_definition"
 )
 
-func ItemObjectToSchema(ctx context.Context, obj *models.Item, d *schema.ResourceData) error {
+func ItemObjectToSchema(ctx context.Context, obj *models.Item, d AttrData) error {
 	if obj == nil {
 		// Object has been deleted
 		return nil
@@ -124,8 +123,8 @@ func ItemObjectToSchema(ctx context.Context, obj *models.Item, d *schema.Resourc
 	return nil
 }
 
-func ItemSchemaToObject(attrType models.ItemType) func(ctx context.Context, d *schema.ResourceData) models.Item {
-	return func(ctx context.Context, d *schema.ResourceData) models.Item {
+func ItemSchemaToObject(attrType models.ItemType) func(ctx context.Context, d AttrData) models.Item {
+	return func(ctx context.Context, d AttrData) models.Item {
 		var obj models.Item
 
 		obj.ID = d.Id()
@@ -153,8 +152,7 @@ func ItemSchemaToObject(attrType models.ItemType) func(ctx context.Context, d *s
 			obj.Reprompt = 1
 		}
 
-		if vSet, ok := d.Get(schema_definition.AttributeCollectionIDs).(*schema.Set); ok {
-			vList := vSet.List()
+		if vList, ok := asInterfaceList(d.Get(schema_definition.AttributeCollectionIDs)); ok {
 			obj.CollectionIds = make([]string, len(vList))
 			for k, v := range vList {
 				obj.CollectionIds[k] = v.(string)

--- a/internal/transformation/list_options_from_data.go
+++ b/internal/transformation/list_options_from_data.go
@@ -1,12 +1,11 @@
 package transformation
 
 import (
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/maxlaverse/terraform-provider-bitwarden/internal/bitwarden"
 	"github.com/maxlaverse/terraform-provider-bitwarden/internal/schema_definition"
 )
 
-func ListOptionsFromData(d *schema.ResourceData) []bitwarden.ListObjectsOption {
+func ListOptionsFromData(d AttrData) []bitwarden.ListObjectsOption {
 	filters := []bitwarden.ListObjectsOption{}
 
 	filterMap := map[string]bitwarden.ListObjectsOptionGenerator{

--- a/internal/transformation/org_collection.go
+++ b/internal/transformation/org_collection.go
@@ -2,14 +2,12 @@ package transformation
 
 import (
 	"context"
-	"hash/fnv"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/maxlaverse/terraform-provider-bitwarden/internal/bitwarden/models"
 	"github.com/maxlaverse/terraform-provider-bitwarden/internal/schema_definition"
 )
 
-func OrganizationCollectionObjectToSchema(ctx context.Context, obj *models.OrgCollection, d *schema.ResourceData) error {
+func OrganizationCollectionObjectToSchema(ctx context.Context, obj *models.OrgCollection, d AttrData) error {
 	if obj == nil {
 		// Object has been deleted
 		return nil
@@ -37,10 +35,8 @@ func OrganizationCollectionObjectToSchema(ctx context.Context, obj *models.OrgCo
 		}
 	}
 
-	userSet := schema.NewSet(func(i interface{}) int {
-		return hashStringToInt(i.(map[string]interface{})[schema_definition.AttributeID].(string))
-	}, users)
-	err = d.Set(schema_definition.AttributeMember, userSet)
+	// Pass a plain slice; *schema.ResourceData.Set wraps TypeSet attributes.
+	err = d.Set(schema_definition.AttributeMember, users)
 	if err != nil {
 		return err
 	}
@@ -55,10 +51,7 @@ func OrganizationCollectionObjectToSchema(ctx context.Context, obj *models.OrgCo
 		}
 	}
 
-	groupSet := schema.NewSet(func(i interface{}) int {
-		return hashStringToInt(i.(map[string]interface{})[schema_definition.AttributeID].(string))
-	}, groups)
-	err = d.Set(schema_definition.AttributeMemberGroup, groupSet)
+	err = d.Set(schema_definition.AttributeMemberGroup, groups)
 	if err != nil {
 		return err
 	}
@@ -66,7 +59,7 @@ func OrganizationCollectionObjectToSchema(ctx context.Context, obj *models.OrgCo
 	return nil
 }
 
-func OrganizationCollectionToObject(ctx context.Context, d *schema.ResourceData) models.OrgCollection {
+func OrganizationCollectionToObject(ctx context.Context, d AttrData) models.OrgCollection {
 	var obj models.OrgCollection
 
 	obj.ID = d.Id()
@@ -80,35 +73,44 @@ func OrganizationCollectionToObject(ctx context.Context, d *schema.ResourceData)
 		obj.OrganizationID = v
 	}
 
-	if v, ok := d.Get(schema_definition.AttributeMember).(*schema.Set); ok {
-		obj.Users = make([]models.OrgCollectionMember, v.Len())
-		for k, v2 := range v.List() {
-			obj.Users[k] = models.OrgCollectionMember{
-				HidePasswords: v2.(map[string]interface{})[schema_definition.AttributeCollectionMemberHidePasswords].(bool),
-				Id:            v2.(map[string]interface{})[schema_definition.AttributeID].(string),
-				ReadOnly:      v2.(map[string]interface{})[schema_definition.AttributeCollectionMemberReadOnly].(bool),
-				Manage:        v2.(map[string]interface{})[schema_definition.AttributeCollectionMemberManage].(bool),
-			}
-		}
-	}
-
-	if v, ok := d.Get(schema_definition.AttributeMemberGroup).(*schema.Set); ok {
-		obj.Groups = make([]models.OrgCollectionMember, v.Len())
-		for k, v2 := range v.List() {
-			obj.Groups[k] = models.OrgCollectionMember{
-				HidePasswords: v2.(map[string]interface{})[schema_definition.AttributeCollectionMemberHidePasswords].(bool),
-				Id:            v2.(map[string]interface{})[schema_definition.AttributeID].(string),
-				ReadOnly:      v2.(map[string]interface{})[schema_definition.AttributeCollectionMemberReadOnly].(bool),
-				Manage:        v2.(map[string]interface{})[schema_definition.AttributeCollectionMemberManage].(bool),
-			}
-		}
-	}
+	obj.Users = orgCollectionMembersFromData(d.Get(schema_definition.AttributeMember))
+	obj.Groups = orgCollectionMembersFromData(d.Get(schema_definition.AttributeMemberGroup))
 
 	return obj
 }
 
-func hashStringToInt(s string) int {
-	h := fnv.New32a()
-	h.Write([]byte(s))
-	return int(h.Sum32())
+func orgCollectionMembersFromData(v interface{}) []models.OrgCollectionMember {
+	vList, ok := asInterfaceList(v)
+	if !ok {
+		return []models.OrgCollectionMember{}
+	}
+
+	members := make([]models.OrgCollectionMember, len(vList))
+	for k, v2 := range vList {
+		m, ok := v2.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		members[k] = models.OrgCollectionMember{
+			HidePasswords: boolFromMap(m, schema_definition.AttributeCollectionMemberHidePasswords),
+			Id:            stringFromMap(m, schema_definition.AttributeID),
+			ReadOnly:      boolFromMap(m, schema_definition.AttributeCollectionMemberReadOnly),
+			Manage:        boolFromMap(m, schema_definition.AttributeCollectionMemberManage),
+		}
+	}
+	return members
+}
+
+func stringFromMap(m map[string]interface{}, key string) string {
+	if v, ok := m[key].(string); ok {
+		return v
+	}
+	return ""
+}
+
+func boolFromMap(m map[string]interface{}, key string) bool {
+	if v, ok := m[key].(bool); ok {
+		return v
+	}
+	return false
 }

--- a/internal/transformation/org_group.go
+++ b/internal/transformation/org_group.go
@@ -3,12 +3,11 @@ package transformation
 import (
 	"context"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/maxlaverse/terraform-provider-bitwarden/internal/bitwarden/models"
 	"github.com/maxlaverse/terraform-provider-bitwarden/internal/schema_definition"
 )
 
-func OrganizationGroupObjectToSchema(ctx context.Context, obj *models.OrgGroup, d *schema.ResourceData) error {
+func OrganizationGroupObjectToSchema(ctx context.Context, obj *models.OrgGroup, d AttrData) error {
 	if obj == nil {
 		// Object has been deleted
 		return nil
@@ -29,7 +28,7 @@ func OrganizationGroupObjectToSchema(ctx context.Context, obj *models.OrgGroup, 
 	return nil
 }
 
-func OrganizationGroupToObject(ctx context.Context, d *schema.ResourceData) models.OrgGroup {
+func OrganizationGroupToObject(ctx context.Context, d AttrData) models.OrgGroup {
 	var obj models.OrgGroup
 
 	obj.ID = d.Id()

--- a/internal/transformation/org_member.go
+++ b/internal/transformation/org_member.go
@@ -3,12 +3,11 @@ package transformation
 import (
 	"context"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/maxlaverse/terraform-provider-bitwarden/internal/bitwarden/models"
 	"github.com/maxlaverse/terraform-provider-bitwarden/internal/schema_definition"
 )
 
-func OrganizationMemberObjectToSchema(ctx context.Context, obj *models.OrgMember, d *schema.ResourceData) error {
+func OrganizationMemberObjectToSchema(ctx context.Context, obj *models.OrgMember, d AttrData) error {
 	if obj == nil {
 		// Object has been deleted
 		return nil
@@ -34,7 +33,7 @@ func OrganizationMemberObjectToSchema(ctx context.Context, obj *models.OrgMember
 	return nil
 }
 
-func OrganizationMemberToObject(ctx context.Context, d *schema.ResourceData) models.OrgMember {
+func OrganizationMemberToObject(ctx context.Context, d AttrData) models.OrgMember {
 	var obj models.OrgMember
 
 	obj.ID = d.Id()

--- a/internal/transformation/organization.go
+++ b/internal/transformation/organization.go
@@ -3,12 +3,11 @@ package transformation
 import (
 	"context"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/maxlaverse/terraform-provider-bitwarden/internal/bitwarden/models"
 	"github.com/maxlaverse/terraform-provider-bitwarden/internal/schema_definition"
 )
 
-func OrganizationObjectToSchema(ctx context.Context, obj *models.Organization, d *schema.ResourceData) error {
+func OrganizationObjectToSchema(ctx context.Context, obj *models.Organization, d AttrData) error {
 	if obj == nil {
 		// Object has been deleted
 		return nil
@@ -24,7 +23,7 @@ func OrganizationObjectToSchema(ctx context.Context, obj *models.Organization, d
 	return nil
 }
 
-func OrganizationSchemaToObject(ctx context.Context, d *schema.ResourceData) models.Organization {
+func OrganizationSchemaToObject(ctx context.Context, d AttrData) models.Organization {
 	var obj models.Organization
 
 	obj.ID = d.Id()

--- a/internal/transformation/project.go
+++ b/internal/transformation/project.go
@@ -3,12 +3,11 @@ package transformation
 import (
 	"context"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/maxlaverse/terraform-provider-bitwarden/internal/bitwarden/models"
 	"github.com/maxlaverse/terraform-provider-bitwarden/internal/schema_definition"
 )
 
-func ProjectSchemaToObject(_ context.Context, d *schema.ResourceData) models.Project {
+func ProjectSchemaToObject(_ context.Context, d AttrData) models.Project {
 	var project models.Project
 
 	project.ID = d.Id()
@@ -23,7 +22,7 @@ func ProjectSchemaToObject(_ context.Context, d *schema.ResourceData) models.Pro
 	return project
 }
 
-func ProjectObjectToSchema(_ context.Context, project *models.Project, d *schema.ResourceData) error {
+func ProjectObjectToSchema(_ context.Context, project *models.Project, d AttrData) error {
 	if project == nil {
 		// Project has been deleted
 		return nil

--- a/internal/transformation/secret.go
+++ b/internal/transformation/secret.go
@@ -3,12 +3,11 @@ package transformation
 import (
 	"context"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/maxlaverse/terraform-provider-bitwarden/internal/bitwarden/models"
 	"github.com/maxlaverse/terraform-provider-bitwarden/internal/schema_definition"
 )
 
-func SecretSchemaToObject(_ context.Context, d *schema.ResourceData) models.Secret {
+func SecretSchemaToObject(_ context.Context, d AttrData) models.Secret {
 	var secret models.Secret
 
 	secret.ID = d.Id()
@@ -35,7 +34,7 @@ func SecretSchemaToObject(_ context.Context, d *schema.ResourceData) models.Secr
 	return secret
 }
 
-func SecretObjectToSchema(_ context.Context, secret *models.Secret, d *schema.ResourceData) error {
+func SecretObjectToSchema(_ context.Context, secret *models.Secret, d AttrData) error {
 	if secret == nil {
 		// Secret has been deleted
 		return nil


### PR DESCRIPTION
Preparing for Plugin Framework migration.

Keep SDKv2 ResourceData as a drop-in AttrData implementation, normalize TypeSet values through List(), and remove the SDK import from the transformation package so Framework can reuse the same mapping later.