### PR TITLE
Add MapData bridge and Framework client helper utilities.

### DIFF
--- a/internal/provider/doc.go
+++ b/internal/provider/doc.go
@@ -2,6 +2,7 @@
 //
 // Migration note: the provider is temporarily served via terraform-plugin-mux,
 // combining a Plugin Framework shell (New) with the SDKv2 implementation (NewSDK).
-// Move resources/data sources to Framework incrementally; remove NewSDK and mux
-// when nothing remains on SDKv2.
+// Shared AttrData transforms plus MapData bridge Framework models to that mapping
+// layer. Move resources/data sources to Framework incrementally; remove NewSDK
+// and mux when nothing remains on SDKv2.
 package provider

--- a/internal/provider/schema_helpers.go
+++ b/internal/provider/schema_helpers.go
@@ -27,6 +27,28 @@ func clientsFromProviderData(providerData any, diags *diag.Diagnostics) (*Provid
 	return clients, true
 }
 
+// requirePasswordManager returns the Password Manager client from provider meta,
+// or records a diagnostic and returns false.
+func requirePasswordManager(clients *ProviderClients, diags *diag.Diagnostics) (bitwarden.PasswordManager, bool) {
+	bwClient, err := clients.RequirePasswordManager()
+	if err != nil {
+		diags.AddError("Provider not configured for Password Manager", err.Error())
+		return nil, false
+	}
+	return bwClient, true
+}
+
+// requireSecretsManager returns the Secrets Manager client from provider meta,
+// or records a diagnostic and returns false.
+func requireSecretsManager(clients *ProviderClients, diags *diag.Diagnostics) (bitwarden.SecretsManager, bool) {
+	bwsClient, err := clients.RequireSecretsManager()
+	if err != nil {
+		diags.AddError("Provider not configured for Secrets Manager", err.Error())
+		return nil, false
+	}
+	return bwsClient, true
+}
+
 // addErr reports a client/API error using the error text as the diagnostic
 // summary, matching the historical SDKv2 diag.FromErr formatting that
 // acceptance tests assert against (e.g. "Error: object not found").

--- a/internal/provider/schema_helpers_test.go
+++ b/internal/provider/schema_helpers_test.go
@@ -1,0 +1,67 @@
+//go:build offline
+
+package provider
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestClientsFromProviderData(t *testing.T) {
+	t.Parallel()
+
+	var diags diag.Diagnostics
+	clients, ok := clientsFromProviderData(nil, &diags)
+	assert.False(t, ok)
+	assert.Nil(t, clients)
+	assert.False(t, diags.HasError())
+
+	diags = nil
+	clients, ok = clientsFromProviderData("wrong", &diags)
+	assert.False(t, ok)
+	assert.Nil(t, clients)
+	assert.True(t, diags.HasError())
+
+	expected := &ProviderClients{}
+	diags = nil
+	clients, ok = clientsFromProviderData(expected, &diags)
+	assert.True(t, ok)
+	assert.Same(t, expected, clients)
+	assert.False(t, diags.HasError())
+}
+
+func TestRequirePasswordManagerMissing(t *testing.T) {
+	t.Parallel()
+
+	var diags diag.Diagnostics
+	client, ok := requirePasswordManager(&ProviderClients{}, &diags)
+	assert.False(t, ok)
+	assert.Nil(t, client)
+	require.True(t, diags.HasError())
+	assert.Equal(t, "Provider not configured for Password Manager", diags[0].Summary())
+}
+
+func TestRequireSecretsManagerMissing(t *testing.T) {
+	t.Parallel()
+
+	var diags diag.Diagnostics
+	client, ok := requireSecretsManager(&ProviderClients{}, &diags)
+	assert.False(t, ok)
+	assert.Nil(t, client)
+	require.True(t, diags.HasError())
+	assert.Equal(t, "Provider not configured for Secrets Manager", diags[0].Summary())
+}
+
+func TestAddErr(t *testing.T) {
+	t.Parallel()
+
+	var diags diag.Diagnostics
+	addErr(&diags, errors.New("object not found"))
+	require.Len(t, diags, 1)
+	assert.Equal(t, "object not found", diags[0].Summary())
+	assert.Empty(t, diags[0].Detail())
+}

--- a/internal/transformation/attrdata.go
+++ b/internal/transformation/attrdata.go
@@ -2,9 +2,10 @@ package transformation
 
 // AttrData is an SDK-agnostic view of Terraform resource/data-source attributes.
 // It decouples domain mapping from terraform-plugin-sdk's *schema.ResourceData
-// so the same mapping logic can later target Plugin Framework state models.
+// so the same mapping logic can target Plugin Framework state via MapData.
 //
-// *schema.ResourceData already satisfies this interface.
+// *schema.ResourceData (SDKv2) and *MapData (Framework bridge) both satisfy this
+// interface.
 type AttrData interface {
 	Id() string
 	SetId(id string)

--- a/internal/transformation/mapdata.go
+++ b/internal/transformation/mapdata.go
@@ -1,0 +1,60 @@
+package transformation
+
+// MapData is an in-memory AttrData backed by a map. Framework resources convert
+// typed plan/state models into a map, run the shared mapping functions in this
+// package, then read Values() back to rebuild the typed model.
+type MapData struct {
+	id     string
+	values map[string]interface{}
+}
+
+// Ensure MapData satisfies AttrData.
+var _ AttrData = (*MapData)(nil)
+
+// NewMapData returns a MapData backed by the given values. A nil map is
+// initialized to an empty one.
+func NewMapData(values map[string]interface{}) *MapData {
+	if values == nil {
+		values = map[string]interface{}{}
+	}
+	return &MapData{values: values}
+}
+
+func (m *MapData) Id() string                     { return m.id }
+func (m *MapData) SetId(id string)                { m.id = id }
+func (m *MapData) Values() map[string]interface{} { return m.values }
+
+func (m *MapData) Get(key string) interface{} {
+	return m.values[key]
+}
+
+// GetOk mimics terraform-plugin-sdk ResourceData.GetOk: false when the key is
+// absent or the value is the type's zero value. Used by ListOptionsFromData.
+func (m *MapData) GetOk(key string) (interface{}, bool) {
+	v, ok := m.values[key]
+	if !ok {
+		return v, false
+	}
+
+	switch vv := v.(type) {
+	case nil:
+		return v, false
+	case string:
+		return vv, len(vv) > 0
+	case bool:
+		return vv, vv
+	case int:
+		return vv, vv != 0
+	case []interface{}:
+		return vv, len(vv) > 0
+	case []string:
+		return vv, len(vv) > 0
+	default:
+		return v, true
+	}
+}
+
+func (m *MapData) Set(key string, value interface{}) error {
+	m.values[key] = value
+	return nil
+}

--- a/internal/transformation/mapdata_test.go
+++ b/internal/transformation/mapdata_test.go
@@ -1,0 +1,148 @@
+package transformation
+
+import (
+	"context"
+	"testing"
+
+	"github.com/maxlaverse/terraform-provider-bitwarden/internal/bitwarden/models"
+	"github.com/maxlaverse/terraform-provider-bitwarden/internal/schema_definition"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewMapDataNil(t *testing.T) {
+	t.Parallel()
+
+	m := NewMapData(nil)
+	require.NotNil(t, m.Values())
+	assert.Empty(t, m.Values())
+	assert.Empty(t, m.Id())
+}
+
+func TestMapDataGetSetId(t *testing.T) {
+	t.Parallel()
+
+	m := NewMapData(map[string]interface{}{
+		schema_definition.AttributeName: "inbox",
+	})
+	assert.Equal(t, "inbox", m.Get(schema_definition.AttributeName))
+	assert.Nil(t, m.Get("missing"))
+
+	m.SetId("folder-1")
+	assert.Equal(t, "folder-1", m.Id())
+
+	require.NoError(t, m.Set(schema_definition.AttributeName, "archive"))
+	assert.Equal(t, "archive", m.Values()[schema_definition.AttributeName])
+}
+
+func TestMapDataGetOk(t *testing.T) {
+	t.Parallel()
+
+	m := NewMapData(map[string]interface{}{
+		"present":      "value",
+		"emptyString":  "",
+		"trueBool":     true,
+		"falseBool":    false,
+		"zeroInt":      0,
+		"nonZeroInt":   3,
+		"emptySlice":   []interface{}{},
+		"slice":        []interface{}{"a"},
+		"emptyStrings": []string{},
+		"strings":      []string{"b"},
+		"nilValue":     nil,
+	})
+
+	v, ok := m.GetOk("present")
+	assert.True(t, ok)
+	assert.Equal(t, "value", v)
+
+	_, ok = m.GetOk("missing")
+	assert.False(t, ok)
+
+	_, ok = m.GetOk("emptyString")
+	assert.False(t, ok)
+
+	_, ok = m.GetOk("falseBool")
+	assert.False(t, ok)
+
+	v, ok = m.GetOk("trueBool")
+	assert.True(t, ok)
+	assert.Equal(t, true, v)
+
+	_, ok = m.GetOk("zeroInt")
+	assert.False(t, ok)
+
+	v, ok = m.GetOk("nonZeroInt")
+	assert.True(t, ok)
+	assert.Equal(t, 3, v)
+
+	_, ok = m.GetOk("emptySlice")
+	assert.False(t, ok)
+
+	v, ok = m.GetOk("slice")
+	assert.True(t, ok)
+	assert.Equal(t, []interface{}{"a"}, v)
+
+	_, ok = m.GetOk("emptyStrings")
+	assert.False(t, ok)
+
+	v, ok = m.GetOk("strings")
+	assert.True(t, ok)
+	assert.Equal(t, []string{"b"}, v)
+
+	_, ok = m.GetOk("nilValue")
+	assert.False(t, ok)
+}
+
+func TestMapDataFolderRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	attr := NewMapData(map[string]interface{}{
+		schema_definition.AttributeName: "Personal",
+	})
+	attr.SetId("")
+
+	obj := SchemaToFolderObject(context.Background(), attr)
+	assert.Equal(t, "Personal", obj.Name)
+	assert.Equal(t, models.ObjectTypeFolder, obj.Object)
+
+	created := &models.Folder{
+		ID:     "folder-abc",
+		Name:   "Personal",
+		Object: models.ObjectTypeFolder,
+	}
+	require.NoError(t, FolderObjectToSchema(context.Background(), created, attr))
+	assert.Equal(t, "folder-abc", attr.Id())
+	assert.Equal(t, "Personal", attr.Values()[schema_definition.AttributeName])
+}
+
+func TestMapDataListOptionsFromData(t *testing.T) {
+	t.Parallel()
+
+	attr := NewMapData(map[string]interface{}{
+		schema_definition.AttributeFilterSearch: "vault",
+		schema_definition.AttributeFilterURL:    "",
+	})
+	opts := ListOptionsFromData(attr)
+	assert.Len(t, opts, 1)
+}
+
+func TestMapDataItemCollectionIDsRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	attr := NewMapData(map[string]interface{}{
+		schema_definition.AttributeName:          "login",
+		schema_definition.AttributeCollectionIDs: []string{"col-1", "col-2"},
+		schema_definition.AttributeFavorite:      true,
+	})
+	attr.SetId("item-1")
+
+	obj := ItemSchemaToObject(models.ItemTypeLogin)(context.Background(), attr)
+	assert.Equal(t, "item-1", obj.ID)
+	assert.Equal(t, []string{"col-1", "col-2"}, obj.CollectionIds)
+	assert.True(t, obj.Favorite)
+
+	require.NoError(t, ItemObjectToSchema(context.Background(), &obj, attr))
+	assert.Equal(t, "item-1", attr.Id())
+	assert.Equal(t, []string{"col-1", "col-2"}, attr.Values()[schema_definition.AttributeCollectionIDs])
+}


### PR DESCRIPTION
Follow up of https://github.com/maxlaverse/terraform-provider-bitwarden/pull/389, https://github.com/maxlaverse/terraform-provider-bitwarden/pull/390, https://github.com/maxlaverse/terraform-provider-bitwarden/pull/391, https://github.com/maxlaverse/terraform-provider-bitwarden/pull/392

**TL;DR;** Last groundwork piece before migrating resources one by one: add the `MapData` AttrData bridge and shared Framework client/diagnostic helpers so later PRs can reuse existing transforms without reinventing glue.

## Summary
- Add `MapData`, an in-memory `AttrData` backed by `map[string]interface{}`, so Framework resources can convert typed plan/state models → shared transforms → typed models again.
- Cover Get/Set/GetOk semantics (including SDKv2-compatible zero-value `GetOk`) plus round-trips through folder/item transforms and `ListOptionsFromData`.
- Add small Framework helpers (`requirePasswordManager` / `requireSecretsManager`) on top of the existing `clientsFromProviderData` / `addErr` utilities, with offline unit tests.
- No resources/data sources moved yet — behavior stays on SDKv2; this only completes the foundation for incremental Framework migration after the next release.
