### PR TITLE
Honor empty vault_path as the CLI default data directory

### DIFF
--- a/internal/bitwarden/bwcli/password_manager.go
+++ b/internal/bitwarden/bwcli/password_manager.go
@@ -540,6 +540,17 @@ func (c *client) env() []string {
 	return defaultEnv
 }
 
+// CLIEnv returns the environment the CLI client would pass to `bw`. Tests use
+// it to assert BITWARDENCLI_APPDATA_DIR handling until we likely make unset
+// vault_path equal the CLI default path in the next major release.
+func CLIEnv(c bitwarden.PasswordManager) ([]string, bool) {
+	cli, ok := c.(*client)
+	if !ok {
+		return nil, false
+	}
+	return cli.env(), true
+}
+
 func (c *client) encode(item interface{}) (string, error) {
 	newOut, err := json.Marshal(item)
 	if err != nil {

--- a/internal/bitwarden/bwcli/password_manager.go
+++ b/internal/bitwarden/bwcli/password_manager.go
@@ -527,8 +527,12 @@ func (c *client) cmdWithSession(args ...string) command.Command {
 }
 
 func (c *client) env() []string {
+	// bw default data dir: HOME (macOS/Linux), XDG_CONFIG_HOME (Linux), APPDATA (Windows).
 	defaultEnv := []string{
-		fmt.Sprintf("PATH=%s", os.Getenv("PATH")),
+		envKV("PATH"),
+		envKV("HOME"),
+		envKV("XDG_CONFIG_HOME"),
+		envKV("APPDATA"),
 		"BW_NOINTERACTION=true",
 	}
 	if len(c.appDataDir) > 0 {
@@ -538,6 +542,10 @@ func (c *client) env() []string {
 		return append(defaultEnv, fmt.Sprintf("NODE_EXTRA_CA_CERTS=%s", c.extraCACertsPath))
 	}
 	return defaultEnv
+}
+
+func envKV(key string) string {
+	return fmt.Sprintf("%s=%s", key, os.Getenv(key))
 }
 
 // CLIEnv returns the environment the CLI client would pass to `bw`. Tests use

--- a/internal/bitwarden/bwcli/password_manager_test.go
+++ b/internal/bitwarden/bwcli/password_manager_test.go
@@ -162,4 +162,8 @@ func TestSettingAppDataDir(t *testing.T) {
 
 	pwWithoutCustomAppDataDir := NewPasswordManagerClient().(*client)
 	assert.NotContains(t, strings.Join(pwWithoutCustomAppDataDir.env(), " "), "BITWARDENCLI_APPDATA_DIR")
+	assert.Contains(t, pwWithoutCustomAppDataDir.env(), envKV("PATH"))
+	assert.Contains(t, pwWithoutCustomAppDataDir.env(), envKV("HOME"))
+	assert.Contains(t, pwWithoutCustomAppDataDir.env(), envKV("XDG_CONFIG_HOME"))
+	assert.Contains(t, pwWithoutCustomAppDataDir.env(), envKV("APPDATA"))
 }

--- a/internal/provider/config.go
+++ b/internal/provider/config.go
@@ -38,6 +38,7 @@ const (
 // is populated from either the Plugin Framework model or SDKv2 ResourceData
 // (with environment-variable fallbacks applied) and consumed by
 // configureClients. Empty strings mean "not set" for all string fields.
+// VaultPath is the exception: omitted vs explicit empty vs a path are distinct.
 type providerConfig struct {
 	Server                                        string
 	Email                                         string
@@ -46,11 +47,37 @@ type providerConfig struct {
 	ClientID                                      string
 	ClientSecret                                  string
 	AccessToken                                   string
-	VaultPath                                     string
+	VaultPath                                     vaultPath
 	ExtraCACertsPath                              string
 	ClientImplementation                          string
 	ExperimentalEmbeddedClient                    bool
 	ExperimentalDisableSyncAfterWriteVerification bool
+}
+
+// vaultPath is vault_path after Configure decoding.
+// Zero value (set=false) means omitted. set && value=="" means use the CLI
+// default data directory. set && value!="" is an explicit path.
+type vaultPath struct {
+	set   bool
+	value string
+}
+
+func explicitVaultPath(value string) vaultPath {
+	return vaultPath{set: true, value: value}
+}
+
+func (p vaultPath) cacheKey() string {
+	if !p.set {
+		return "\x00<unset>"
+	}
+	return p.value
+}
+
+func (p vaultPath) appDataDir() (string, bool) {
+	if !p.set || p.value == "" {
+		return "", false
+	}
+	return p.value, true
 }
 
 func (c providerConfig) has(value string) bool { return len(value) > 0 }
@@ -67,7 +94,7 @@ func (c providerConfig) cacheKey(version string) string {
 		c.ClientID,
 		c.ClientSecret,
 		c.AccessToken,
-		c.VaultPath,
+		c.VaultPath.cacheKey(),
 		c.ExtraCACertsPath,
 		c.ClientImplementation,
 		fmt.Sprintf("%t", c.ExperimentalEmbeddedClient),
@@ -141,7 +168,7 @@ func providerConfigFromResourceData(d *schema.ResourceData) providerConfig {
 		ClientID:             stringFromResourceData(d, schema_definition.AttributeClientID),
 		ClientSecret:         stringFromResourceData(d, schema_definition.AttributeClientSecret),
 		AccessToken:          stringFromResourceData(d, schema_definition.AttributeBwsAccessToken),
-		VaultPath:            stringFromResourceData(d, schema_definition.AttributeVaultPath),
+		VaultPath:            vaultPathFromResourceData(d, schema_definition.AttributeVaultPath),
 		ExtraCACertsPath:     stringFromResourceData(d, schema_definition.AttributeExtraCACertsPath),
 		ClientImplementation: stringFromResourceData(d, schema_definition.AttributeClientImplementation),
 	}
@@ -169,11 +196,36 @@ func stringFromResourceData(d *schema.ResourceData, key string) string {
 	return ""
 }
 
+// vaultPathFromResourceData distinguishes an omitted attribute from an
+// explicit empty string. Prefer raw config (null vs "") so muxed SDKv2
+// Configure matches the Framework half; GetOkExists is a fallback for
+// ResourceData without raw config.
+func vaultPathFromResourceData(d *schema.ResourceData, key string) vaultPath {
+	raw := d.GetRawConfig()
+	if !raw.IsNull() && raw.IsKnown() && raw.Type().IsObjectType() {
+		if _, ok := raw.Type().AttributeTypes()[key]; ok {
+			attr := raw.GetAttr(key)
+			if attr.IsNull() || !attr.IsKnown() {
+				return vaultPath{}
+			}
+			return explicitVaultPath(attr.AsString())
+		}
+	}
+
+	v, ok := d.GetOkExists(key)
+	if !ok {
+		return vaultPath{}
+	}
+	s, _ := v.(string)
+	return explicitVaultPath(s)
+}
+
 // applyProviderConfigEnvDefaults fills empty config fields from the environment
 // (and hard-coded defaults), replacing SDKv2 schema DefaultFunc behaviour.
 //
-// Note: an explicitly empty vault_path currently cannot be distinguished from
-// "unset", so "" still falls through to BITWARDENCLI_APPDATA_DIR / .bitwarden/.
+// An explicitly empty vault_path is left empty so the CLI uses its own default
+// data directory. Omitted vault_path still falls through to
+// BITWARDENCLI_APPDATA_DIR / .bitwarden/.
 func applyProviderConfigEnvDefaults(cfg providerConfig) providerConfig {
 	cfg.Server = firstNonEmpty(cfg.Server, envFirst("BW_URL", "BWS_SERVER_URL"), bitwarden.DefaultBitwardenServerURL)
 	cfg.Email = firstNonEmpty(cfg.Email, envFirst("BW_EMAIL"))
@@ -182,7 +234,9 @@ func applyProviderConfigEnvDefaults(cfg providerConfig) providerConfig {
 	cfg.ClientID = firstNonEmpty(cfg.ClientID, envFirst("BW_CLIENTID"))
 	cfg.ClientSecret = firstNonEmpty(cfg.ClientSecret, envFirst("BW_CLIENTSECRET"))
 	cfg.AccessToken = firstNonEmpty(cfg.AccessToken, envFirst("BWS_ACCESS_TOKEN"))
-	cfg.VaultPath = firstNonEmpty(cfg.VaultPath, envFirst("BITWARDENCLI_APPDATA_DIR"), ".bitwarden/")
+	if !cfg.VaultPath.set {
+		cfg.VaultPath = explicitVaultPath(firstNonEmpty(envFirst("BITWARDENCLI_APPDATA_DIR"), ".bitwarden/"))
+	}
 	cfg.ExtraCACertsPath = firstNonEmpty(cfg.ExtraCACertsPath, envFirst("NODE_EXTRA_CA_CERTS"))
 	return cfg
 }
@@ -415,8 +469,8 @@ func logoutIfIdentityChanged(ctx context.Context, cfg providerConfig, bwClient b
 
 func newCLIPasswordManagerClient(cfg providerConfig, version string) (bwcli.PasswordManagerClient, error) {
 	opts := []bwcli.Options{}
-	if cfg.has(cfg.VaultPath) {
-		abs, err := filepath.Abs(cfg.VaultPath)
+	if dir, ok := cfg.VaultPath.appDataDir(); ok {
+		abs, err := filepath.Abs(dir)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/provider/config_mux_test.go
+++ b/internal/provider/config_mux_test.go
@@ -17,7 +17,7 @@ func TestConfigureClientsMuxHandoff(t *testing.T) {
 		ClientID:             "client-id-mux",
 		ClientSecret:         "client-secret-mux",
 		MasterPassword:       "master-password-mux",
-		VaultPath:            t.TempDir(),
+		VaultPath:            explicitVaultPath(t.TempDir()),
 		ClientImplementation: schema_definition.ClientImplementationEmbedded,
 	}
 
@@ -42,7 +42,7 @@ func TestConfigureClientsTakeWithoutOffer(t *testing.T) {
 		ClientID:             "client-id-solo",
 		ClientSecret:         "client-secret-solo",
 		MasterPassword:       "master-password-solo",
-		VaultPath:            t.TempDir(),
+		VaultPath:            explicitVaultPath(t.TempDir()),
 		ClientImplementation: schema_definition.ClientImplementationEmbedded,
 	}
 
@@ -60,7 +60,7 @@ func TestConfigureClientsOfferReplacesOrphan(t *testing.T) {
 		ClientID:             "client-id-orphan",
 		ClientSecret:         "client-secret-orphan",
 		MasterPassword:       "master-password-orphan",
-		VaultPath:            t.TempDir(),
+		VaultPath:            explicitVaultPath(t.TempDir()),
 		ClientImplementation: schema_definition.ClientImplementationEmbedded,
 	}
 

--- a/internal/provider/config_vault_path_test.go
+++ b/internal/provider/config_vault_path_test.go
@@ -1,0 +1,191 @@
+//go:build offline
+
+package provider
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/go-cty/cty"
+	fwprovider "github.com/hashicorp/terraform-plugin-framework/provider"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/maxlaverse/terraform-provider-bitwarden/internal/bitwarden"
+	"github.com/maxlaverse/terraform-provider-bitwarden/internal/bitwarden/bwcli"
+	"github.com/maxlaverse/terraform-provider-bitwarden/internal/schema_definition"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type vaultPathAppDataCase struct {
+	name           string
+	vaultPath      *string
+	wantAppDataDir bool
+	expectedDir    string
+}
+
+func vaultPathAppDataCases(t *testing.T) []vaultPathAppDataCase {
+	t.Helper()
+
+	custom := "custom_app_dir"
+	customAbs, err := filepath.Abs(custom)
+	require.NoError(t, err)
+	defaultAbs, err := filepath.Abs(".bitwarden/")
+	require.NoError(t, err)
+	empty := ""
+
+	return []vaultPathAppDataCase{
+		{
+			name:           "omitted uses .bitwarden",
+			vaultPath:      nil,
+			wantAppDataDir: true,
+			expectedDir:    defaultAbs,
+		},
+		{
+			name:           "empty omits BITWARDENCLI_APPDATA_DIR",
+			vaultPath:      &empty,
+			wantAppDataDir: false,
+		},
+		{
+			name:           "set uses provided path",
+			vaultPath:      &custom,
+			wantAppDataDir: true,
+			expectedDir:    customAbs,
+		},
+	}
+}
+
+func TestCLIAppDataDirFromVaultPath_FrameworkConfigure(t *testing.T) {
+	t.Setenv("BITWARDENCLI_APPDATA_DIR", "")
+
+	for _, tc := range vaultPathAppDataCases(t) {
+		t.Run(tc.name, func(t *testing.T) {
+			pm := configureFrameworkWithVaultPath(t, tc.vaultPath)
+			assertCLIAppDataDir(t, pm, tc.wantAppDataDir, tc.expectedDir)
+		})
+	}
+}
+
+func TestCLIAppDataDirFromVaultPath_SDKConfigure(t *testing.T) {
+	t.Setenv("BITWARDENCLI_APPDATA_DIR", "")
+
+	for _, tc := range vaultPathAppDataCases(t) {
+		t.Run(tc.name, func(t *testing.T) {
+			pm := configureSDKWithVaultPath(t, tc.vaultPath)
+			assertCLIAppDataDir(t, pm, tc.wantAppDataDir, tc.expectedDir)
+		})
+	}
+}
+
+func TestApplyProviderConfigEnvDefaults_VaultPath(t *testing.T) {
+	t.Run("omitted uses environment", func(t *testing.T) {
+		t.Setenv("BITWARDENCLI_APPDATA_DIR", "/custom/cli-dir")
+		cfg := applyProviderConfigEnvDefaults(providerConfig{})
+		assert.Equal(t, explicitVaultPath("/custom/cli-dir"), cfg.VaultPath)
+	})
+
+	t.Run("explicit empty skips environment", func(t *testing.T) {
+		t.Setenv("BITWARDENCLI_APPDATA_DIR", "/custom/cli-dir")
+		cfg := applyProviderConfigEnvDefaults(providerConfig{VaultPath: explicitVaultPath("")})
+		assert.Equal(t, explicitVaultPath(""), cfg.VaultPath)
+	})
+}
+
+func configureFrameworkWithVaultPath(t *testing.T, vaultPath *string) bitwarden.PasswordManager {
+	t.Helper()
+	ctx := t.Context()
+	p := New(versionTestSkippedLogin)()
+
+	var schemaResp fwprovider.SchemaResponse
+	p.Schema(ctx, fwprovider.SchemaRequest{}, &schemaResp)
+	require.False(t, schemaResp.Diagnostics.HasError(), schemaResp.Diagnostics)
+
+	objType, ok := schemaResp.Schema.Type().TerraformType(ctx).(tftypes.Object)
+	require.True(t, ok)
+
+	attrs := make(map[string]tftypes.Value, len(objType.AttributeTypes))
+	for name, typ := range objType.AttributeTypes {
+		attrs[name] = tftypes.NewValue(typ, nil)
+	}
+	attrs[schema_definition.AttributeSessionKey] = tftypes.NewValue(tftypes.String, t.Name())
+	if vaultPath != nil {
+		attrs[schema_definition.AttributeVaultPath] = tftypes.NewValue(tftypes.String, *vaultPath)
+	}
+
+	var resp fwprovider.ConfigureResponse
+	p.Configure(ctx, fwprovider.ConfigureRequest{
+		Config: tfsdk.Config{
+			Raw:    tftypes.NewValue(objType, attrs),
+			Schema: schemaResp.Schema,
+		},
+	}, &resp)
+	require.False(t, resp.Diagnostics.HasError(), fmt.Sprintf("%v", resp.Diagnostics))
+
+	clients, ok := resp.ResourceData.(*ProviderClients)
+	require.True(t, ok)
+	pm, err := clients.RequirePasswordManager()
+	require.NoError(t, err)
+	return pm
+}
+
+func configureSDKWithVaultPath(t *testing.T, vaultPath *string) bitwarden.PasswordManager {
+	t.Helper()
+	sdk := NewSDK(versionTestSkippedLogin)()
+
+	raw := map[string]interface{}{
+		schema_definition.AttributeSessionKey: t.Name(),
+	}
+	if vaultPath != nil {
+		raw[schema_definition.AttributeVaultPath] = *vaultPath
+	}
+
+	typ := schema.InternalMap(sdk.Schema).CoreConfigSchema().ImpliedType()
+	vals := make(map[string]cty.Value, len(typ.AttributeTypes()))
+	for name, at := range typ.AttributeTypes() {
+		vals[name] = cty.NullVal(at)
+	}
+	vals[schema_definition.AttributeSessionKey] = cty.StringVal(t.Name())
+	if vaultPath != nil {
+		vals[schema_definition.AttributeVaultPath] = cty.StringVal(*vaultPath)
+	}
+
+	cfg := terraform.NewResourceConfigRaw(raw)
+	cfg.CtyValue = cty.ObjectVal(vals)
+
+	diags := sdk.Configure(t.Context(), cfg)
+	require.False(t, diags.HasError(), diags)
+
+	clients, ok := sdk.Meta().(*ProviderClients)
+	require.True(t, ok)
+	pm, err := clients.RequirePasswordManager()
+	require.NoError(t, err)
+	return pm
+}
+
+func assertCLIAppDataDir(t *testing.T, pm bitwarden.PasswordManager, wantSet bool, wantDir string) {
+	t.Helper()
+	env, ok := bwcli.CLIEnv(pm)
+	require.True(t, ok, "expected a CLI password manager client")
+
+	dir, set := cliAppDataDir(env)
+	if !wantSet {
+		assert.False(t, set, "BITWARDENCLI_APPDATA_DIR should not be set, got %q", dir)
+		return
+	}
+	require.True(t, set, "BITWARDENCLI_APPDATA_DIR should be set")
+	assert.Equal(t, wantDir, dir)
+}
+
+func cliAppDataDir(env []string) (string, bool) {
+	const prefix = "BITWARDENCLI_APPDATA_DIR="
+	for _, e := range env {
+		if strings.HasPrefix(e, prefix) {
+			return strings.TrimPrefix(e, prefix), true
+		}
+	}
+	return "", false
+}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -154,7 +154,7 @@ func (p *bitwardenProvider) Configure(ctx context.Context, req provider.Configur
 		ClientID:             model.ClientID.ValueString(),
 		ClientSecret:         model.ClientSecret.ValueString(),
 		AccessToken:          model.AccessToken.ValueString(),
-		VaultPath:            model.VaultPath.ValueString(),
+		VaultPath:            vaultPathFromFramework(model.VaultPath),
 		ExtraCACertsPath:     model.ExtraCACerts.ValueString(),
 		ClientImplementation: model.ClientImplementation.ValueString(),
 	})
@@ -186,6 +186,13 @@ func (p *bitwardenProvider) Configure(ctx context.Context, req provider.Configur
 
 	resp.ResourceData = clients
 	resp.DataSourceData = clients
+}
+
+func vaultPathFromFramework(v types.String) vaultPath {
+	if v.IsNull() || v.IsUnknown() {
+		return vaultPath{}
+	}
+	return explicitVaultPath(v.ValueString())
 }
 
 func (p *bitwardenProvider) ownsManagedResources(ctx context.Context) bool {


### PR DESCRIPTION
Follow up of https://github.com/maxlaverse/terraform-provider-bitwarden/pull/392, fixes https://github.com/maxlaverse/terraform-provider-bitwarden/issues/403

**TL;DR;** Restore `vault_path = ""` so the CLI uses its own data directory instead of `.bitwarden/`.

## Summary
- Distinguish omitted, empty, and set `vault_path` on both mux Configure paths.
- Skip `BITWARDENCLI_APPDATA_DIR` when `vault_path` is explicitly empty; keep `.bitwarden/` / env when it is omitted.
- Cover Framework and SDKv2 Configure against the resulting CLI env.
